### PR TITLE
Control Drone With Core Autonomy Stack

### DIFF
--- a/firefly_bringup/CMakeLists.txt
+++ b/firefly_bringup/CMakeLists.txt
@@ -186,6 +186,7 @@ catkin_install_python(PROGRAMS
 install(FILES
   launch/gcs_bringup.launch
   launch/onboard_bringup.launch
+  launch/ca_bringup.launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/firefly_bringup/launch/ca_bringup.launch
+++ b/firefly_bringup/launch/ca_bringup.launch
@@ -1,0 +1,27 @@
+<launch>
+
+  <arg name="robot_name" default="firefly" />
+  <arg name="drone_interface" default="DJIInterface" />
+
+  <group ns="$(arg robot_name)">
+    <include file="$(find dji_sdk)/launch/sdk.launch" unless="$(arg replay_mode)" />
+
+
+    <!-- state estimation -->
+    <include file="$(find core_central)/launch/dji/sim/dji_sim_state_estimation.launch" pass_all_args="true" />
+
+    <!-- control -->
+    <include file="$(find core_central)/launch/dji/sim/dji_sim_control.launch" pass_all_args="true" />
+
+    <!-- autonomy -->
+    <include file="$(find firefly_control)/launch/autonomy.launch" pass_all_args="true" />
+
+    <!-- visualization -->
+    <include file="$(find core_central)/launch/common/visualization.launch" pass_all_args="true" />
+
+    <!-- logging -->
+    <!-- <node name="record" pkg="rosbag" type="record" args="-a -o ~/bags/dji" /> -->
+
+  </group>
+
+</launch>

--- a/firefly_bringup/launch/ca_bringup.launch
+++ b/firefly_bringup/launch/ca_bringup.launch
@@ -1,10 +1,14 @@
 <launch>
+  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find firefly_bringup)/config/rosconsole.config"/>
+  <env name="ROS_PYTHON_LOG_CONFIG_FILE" value="$(find firefly_bringup)/config/python_logging.conf"/>
 
-  <arg name="robot_name" default="firefly" />
+  <arg name="robot_name" default="uav1" />
   <arg name="drone_interface" default="DJIInterface" />
 
   <group ns="$(arg robot_name)">
-    <include file="$(find dji_sdk)/launch/sdk.launch" unless="$(arg replay_mode)" />
+    <include file="$(find dji_sdk)/launch/sdk.launch"/>
+
+    <node pkg="firefly_telemetry" type="onboard_telemetry.py" name="onboard_telemetry" output="screen"/>
 
 
     <!-- state estimation -->
@@ -17,7 +21,7 @@
     <include file="$(find firefly_control)/launch/autonomy.launch" pass_all_args="true" />
 
     <!-- visualization -->
-    <include file="$(find core_central)/launch/common/visualization.launch" pass_all_args="true" />
+    <!-- <include file="$(find core_central)/launch/common/visualization.launch" pass_all_args="true" /> -->
 
     <!-- logging -->
     <!-- <node name="record" pkg="rosbag" type="record" args="-a -o ~/bags/dji" /> -->

--- a/firefly_bringup/launch/ca_vis_bringup.launch
+++ b/firefly_bringup/launch/ca_vis_bringup.launch
@@ -1,0 +1,11 @@
+<launch>
+  <arg name="robot_name" default="uav1" />
+  <arg name="drone_interface" default="DJIInterface" />
+
+  <group ns="$(arg robot_name)">
+    <!-- visualization -->
+    <include file="$(find core_central)/launch/common/visualization.launch" pass_all_args="true" />
+
+  </group>
+
+</launch>

--- a/firefly_control/CMakeLists.txt
+++ b/firefly_control/CMakeLists.txt
@@ -11,17 +11,21 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
   dji_sdk
+  sensor_msgs
+  behavior_tree
+  behavior_tree_msgs
+  core_takeoff_landing_planner
+  core_trajectory_controller
+  core_drone_interface
+  core_trajectory_msgs
 )
+
+find_package(base)
 
 find_package(DJIOSDK REQUIRED)
 
 
-catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES firefly_control
-#  CATKIN_DEPENDS roscpp std_msgs
-#  DEPENDS system_lib
-)
+catkin_package()
 
 ###########
 ## Build ##
@@ -32,25 +36,25 @@ catkin_package(
 include_directories(
  include
   ${catkin_INCLUDE_DIRS}
+  ${base_INCLUDE_DIRS}
 )
 
 
 add_executable(waypoint_mission src/waypoint_mission.cpp)
-
 add_dependencies(waypoint_mission ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
 target_link_libraries(waypoint_mission ${catkin_LIBRARIES} ${DJIOSDK_LIBRARIES})
 
 add_executable(takeoff_land_test src/takeoff_land_test.cpp)
-
 add_dependencies(takeoff_land_test ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
 target_link_libraries(takeoff_land_test ${catkin_LIBRARIES} ${DJIOSDK_LIBRARIES})
 
 add_executable(simple_waypoint_test src/simple_waypoint_test.cpp)
-
 add_dependencies(simple_waypoint_test ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
 target_link_libraries(simple_waypoint_test ${catkin_LIBRARIES} ${DJIOSDK_LIBRARIES})
 
-
+add_executable(behavior_executive src/behavior_executive.cpp)
+add_dependencies(behavior_executive ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${base_EXPORTED_TARGETS})
+target_link_libraries(behavior_executive
+  ${catkin_LIBRARIES}
+  ${base_LIBRARIES}
+)

--- a/firefly_control/config/firefly.tree
+++ b/firefly_control/config/firefly.tree
@@ -6,7 +6,7 @@
 				(Armed)
 			[Disarm]
 	->
-		(Offboard Commanded)
+		(Request Control Commanded)
 		?
 			(Offboard Mode)
 			[Request Control]

--- a/firefly_control/config/firefly.tree
+++ b/firefly_control/config/firefly.tree
@@ -1,0 +1,27 @@
+?
+	->
+		(Disarm Commanded)
+		?
+			<!>
+				(Armed)
+			[Disarm]
+	->
+		(Offboard Commanded)
+		?
+			(Offboard Mode)
+			[Request Control]
+	->
+		(Takeoff Commanded)
+		?
+			(Takeoff Complete)
+			[Takeoff]
+	->
+		(Land Commanded)
+		?
+			(Landed)
+			[Land]
+	->
+		(Arm Commanded)
+		?
+			(Armed)
+			[Arm]

--- a/firefly_control/config/firefly.tree
+++ b/firefly_control/config/firefly.tree
@@ -25,3 +25,7 @@
 		?
 			(Armed)
 			[Arm]
+	->	
+		(Traj Control Commanded)
+		?
+			[Traj Control]

--- a/firefly_control/include/behavior_executive.h
+++ b/firefly_control/include/behavior_executive.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <base/BaseNode.h>
+#include <behavior_tree/behavior_tree.h>
+#include <behavior_tree_msgs/BehaviorTreeCommand.h>
+#include <behavior_tree_msgs/BehaviorTreeCommands.h>
+#include <behavior_tree_msgs/Status.h>
+#include <core_drone_interface/DroneCommand.h>
+#include <core_takeoff_landing_planner/TakeoffLandingCommand.h>
+#include <core_trajectory_controller/TrajectoryMode.h>
+#include <core_trajectory_msgs/FixedTrajectory.h>
+#include <std_msgs/Bool.h>
+#include <std_msgs/String.h>
+#include <std_srvs/Empty.h>
+
+#include <string>
+
+class BehaviorExecutiveBehaviorTree : public BaseNode {
+ private:
+  // variables
+  std::string takeoff_state, landing_state;
+  core_trajectory_msgs::FixedTrajectory fixed_trajectory;
+
+  // conditions
+  std::vector<bt::Condition *> conditions;
+  bt::Condition *takeoff_commanded_condition;
+  bt::Condition *land_commanded_condition;
+  bt::Condition *pause_commanded_condition;
+  bt::Condition *fixed_trajectory_commanded_condition;
+  bt::Condition *explore_commanded_condition;
+  bt::Condition *autonomously_explore_commanded_condition;
+  bt::Condition *offboard_commanded_condition;
+  bt::Condition *arm_commanded_condition;
+  bt::Condition *disarm_commanded_condition;
+  bt::Condition *rewind_commanded_condition;
+  bt::Condition *offboard_mode_condition;
+  bt::Condition *armed_condition;
+  bt::Condition *takeoff_complete_condition;
+  bt::Condition *landed_condition;
+  bt::Condition *in_air_condition;
+
+  // actions
+  std::vector<bt::Action *> actions;
+  bt::Action *takeoff_action;
+  bt::Action *land_action;
+  bt::Action *pause_action;
+  bt::Action *follow_fixed_trajectory_action;
+  bt::Action *explore_action;
+  bt::Action *request_control_action;
+  bt::Action *arm_action;
+  bt::Action *disarm_action;
+  bt::Action *rewind_action;
+
+  // services
+  ros::ServiceClient takeoff_landing_client;
+  ros::ServiceClient trajectory_mode_client;
+  ros::ServiceClient drone_command_client;
+  ros::ServiceClient x_reset_integrator_client, y_reset_integrator_client,
+      z_reset_integrator_client, yaw_reset_integrator_client;
+  ros::ServiceClient vx_reset_integrator_client, vy_reset_integrator_client,
+      vz_reset_integrator_client, yawrate_reset_integrator_client;
+
+  // publishers
+  ros::Publisher fixed_trajectory_pub;
+  ros::Publisher in_air_pub;
+
+  // subscribers
+  ros::Subscriber behavior_tree_command_sub;
+  ros::Subscriber takeoff_state_sub;
+  ros::Subscriber landing_state_sub;
+  ros::Subscriber fixed_trajectory_command_sub;
+  ros::Subscriber has_control_sub;
+  ros::Subscriber is_armed_sub;
+
+  // callbacks
+  void behavior_tree_command_callback(
+      behavior_tree_msgs::BehaviorTreeCommands msg);
+  void takeoff_state_callback(std_msgs::String msg);
+  void landing_state_callback(std_msgs::String msg);
+  void fixed_trajectory_command_callback(
+      core_trajectory_msgs::FixedTrajectory msg);
+  void has_control_callback(std_msgs::Bool msg);
+  void is_armed_callback(std_msgs::Bool msg);
+
+ public:
+  BehaviorExecutiveBehaviorTree(std::string node_name);
+
+  virtual bool initialize();
+  virtual bool execute();
+  virtual ~BehaviorExecutiveBehaviorTree();
+};

--- a/firefly_control/include/behavior_executive.h
+++ b/firefly_control/include/behavior_executive.h
@@ -15,7 +15,7 @@
 
 #include <string>
 
-class BehaviorExecutiveBehaviorTree : public BaseNode {
+class BehaviorExecutive : public BaseNode {
  private:
   // variables
   std::string takeoff_state, landing_state;
@@ -23,16 +23,14 @@ class BehaviorExecutiveBehaviorTree : public BaseNode {
 
   // conditions
   std::vector<bt::Condition *> conditions;
-  bt::Condition *takeoff_commanded_condition;
-  bt::Condition *land_commanded_condition;
-  bt::Condition *pause_commanded_condition;
-  bt::Condition *fixed_trajectory_commanded_condition;
-  bt::Condition *explore_commanded_condition;
-  bt::Condition *autonomously_explore_commanded_condition;
-  bt::Condition *offboard_commanded_condition;
+
+  bt::Condition *request_control_commanded_condition;
   bt::Condition *arm_commanded_condition;
   bt::Condition *disarm_commanded_condition;
-  bt::Condition *rewind_commanded_condition;
+  bt::Condition *takeoff_commanded_condition;
+  bt::Condition *land_commanded_condition;
+  bt::Condition *traj_control_commanded_condition;
+
   bt::Condition *offboard_mode_condition;
   bt::Condition *armed_condition;
   bt::Condition *takeoff_complete_condition;
@@ -41,15 +39,12 @@ class BehaviorExecutiveBehaviorTree : public BaseNode {
 
   // actions
   std::vector<bt::Action *> actions;
-  bt::Action *takeoff_action;
-  bt::Action *land_action;
-  bt::Action *pause_action;
-  bt::Action *follow_fixed_trajectory_action;
-  bt::Action *explore_action;
   bt::Action *request_control_action;
   bt::Action *arm_action;
   bt::Action *disarm_action;
-  bt::Action *rewind_action;
+  bt::Action *takeoff_action;
+  bt::Action *land_action;
+  bt::Action *traj_control_action;
 
   // services
   ros::ServiceClient takeoff_landing_client;
@@ -83,9 +78,9 @@ class BehaviorExecutiveBehaviorTree : public BaseNode {
   void is_armed_callback(std_msgs::Bool msg);
 
  public:
-  BehaviorExecutiveBehaviorTree(std::string node_name);
+  BehaviorExecutive(std::string node_name);
 
   virtual bool initialize();
   virtual bool execute();
-  virtual ~BehaviorExecutiveBehaviorTree();
+  virtual ~BehaviorExecutive();
 };

--- a/firefly_control/include/behavior_executive.h
+++ b/firefly_control/include/behavior_executive.h
@@ -9,6 +9,7 @@
 #include <core_takeoff_landing_planner/TakeoffLandingCommand.h>
 #include <core_trajectory_controller/TrajectoryMode.h>
 #include <core_trajectory_msgs/FixedTrajectory.h>
+#include <diagnostic_msgs/KeyValue.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/String.h>
 #include <std_srvs/Empty.h>
@@ -19,7 +20,6 @@ class BehaviorExecutive : public BaseNode {
  private:
   // variables
   std::string takeoff_state, landing_state;
-  core_trajectory_msgs::FixedTrajectory fixed_trajectory;
 
   // conditions
   std::vector<bt::Condition *> conditions;
@@ -63,7 +63,6 @@ class BehaviorExecutive : public BaseNode {
   ros::Subscriber behavior_tree_command_sub;
   ros::Subscriber takeoff_state_sub;
   ros::Subscriber landing_state_sub;
-  ros::Subscriber fixed_trajectory_command_sub;
   ros::Subscriber has_control_sub;
   ros::Subscriber is_armed_sub;
 
@@ -72,8 +71,6 @@ class BehaviorExecutive : public BaseNode {
       behavior_tree_msgs::BehaviorTreeCommands msg);
   void takeoff_state_callback(std_msgs::String msg);
   void landing_state_callback(std_msgs::String msg);
-  void fixed_trajectory_command_callback(
-      core_trajectory_msgs::FixedTrajectory msg);
   void has_control_callback(std_msgs::Bool msg);
   void is_armed_callback(std_msgs::Bool msg);
 

--- a/firefly_control/launch/autonomy.launch
+++ b/firefly_control/launch/autonomy.launch
@@ -1,0 +1,46 @@
+<launch>
+
+  <arg name="robot_name" default="firefly" />
+  <arg name="drone_interface" default="DJIInterface" />
+  <arg name="map_representation" default="PointCloudMapRepresentation" />
+
+  <!-- static transforms -->
+  <node name="world_to_$(arg robot_name)_map" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 0 /world $(arg robot_name)/map 10" />
+
+  <!-- behavior -->
+  <node name="behavior_tree" pkg="behavior_tree" type="behavior_tree_node.py">
+    <param name="config" type="string" value="$(find firefly_control)/config/drone.tree" />
+  </node>
+  <node name="behavior_executive" pkg="firefly_control" type="behavior_tree" output="screen">
+    <param name="execute_target" type="double" value="10." />
+  </node>
+  <include file="$(find core_drone_interface)/launch/drone_interface_node.launch" pass_all_args="true" />
+
+  <!-- planning -->
+  <include file="$(find core_takeoff_landing_planner)/launch/takeoff_landing_planner.launch" />
+  <node name="global_plan_fixed_trajectory_generator" pkg="core_trajectory_library" type="fixed_trajectory_generator.py">
+    <remap from="fixed_trajectory" to="global_plan_fixed_trajectory" />
+    <remap from="trajectory_track" to="global_plan" />
+  </node>
+  <!-- <node name="fixed_trajectory_generator" pkg="core_trajectory_library" type="fixed_trajectory_generator.py"></node> -->
+  <include file="$(find core_local_planner)/launch/local_planner.launch" pass_all_args="true" />
+  <include file="$(find core_trajectory_controller)/launch/trajectory_controller.launch" pass_all_args="true" />
+
+  <!-- perception -->
+  <!-- <node name="front_stereo" pkg="stereo_image_proc" type="stereo_image_proc" ns="front_stereo" /> -->
+  <!-- <node pkg="disparity_expansion" type="disparity_conv" name="disparity_conv"/>
+  <node pkg="disparity_expansion" type="disparity_expansion_clean" name="disparity_expansion">
+    <param name="lut_max_disparity" type="int" value="180" />
+    <param name="robot_radius" type="double" value="1.0" />
+    <param name="bg_multiplier" type="double" value="2.0" />
+    <param name="sensor_pixel_error" type="double" value="0.5" />
+    <param name="padding" type="double" value="-1" />
+    
+    <remap from="/nerian_sp1/right/camera_info" to="front_stereo/right/camera_info" />
+    <remap from="/nerian_sp1/disparity_map_32F" to="front_stereo/disparity" />
+    
+    <remap from="/ceye/left/expanded_disparity_fg" to="front_stereo/left/disparity_expanded_fg" />
+    <remap from="/ceye/left/expanded_disparity_bg" to="front_stereo/left/disparity_expanded_bg" />
+  </node> -->
+
+</launch>

--- a/firefly_control/launch/autonomy.launch
+++ b/firefly_control/launch/autonomy.launch
@@ -18,12 +18,12 @@
 
   <!-- planning -->
   <include file="$(find core_takeoff_landing_planner)/launch/takeoff_landing_planner.launch" />
-  <node name="global_plan_fixed_trajectory_generator" pkg="core_trajectory_library" type="fixed_trajectory_generator.py">
+  <!-- <node name="global_plan_fixed_trajectory_generator" pkg="core_trajectory_library" type="fixed_trajectory_generator.py">
     <remap from="fixed_trajectory" to="global_plan_fixed_trajectory" />
     <remap from="trajectory_track" to="global_plan" />
-  </node>
-  <!-- <node name="fixed_trajectory_generator" pkg="core_trajectory_library" type="fixed_trajectory_generator.py"></node> -->
-  <include file="$(find core_local_planner)/launch/local_planner.launch" pass_all_args="true" />
+  </node> -->
+  <node name="fixed_trajectory_generator" pkg="firefly_control" type="fixed_trajectory_generator.py"></node>
+  <!-- <include file="$(find core_local_planner)/launch/local_planner.launch" pass_all_args="true" /> -->
   <include file="$(find core_trajectory_controller)/launch/trajectory_controller.launch" pass_all_args="true" />
 
   <!-- perception -->

--- a/firefly_control/launch/autonomy.launch
+++ b/firefly_control/launch/autonomy.launch
@@ -1,6 +1,6 @@
 <launch>
 
-  <arg name="robot_name" default="firefly" />
+  <arg name="robot_name" default="uav1" />
   <arg name="drone_interface" default="DJIInterface" />
   <arg name="map_representation" default="PointCloudMapRepresentation" />
 
@@ -9,9 +9,9 @@
 
   <!-- behavior -->
   <node name="behavior_tree" pkg="behavior_tree" type="behavior_tree_node.py">
-    <param name="config" type="string" value="$(find firefly_control)/config/drone.tree" />
+    <param name="config" type="string" value="$(find firefly_control)/config/firefly.tree" />
   </node>
-  <node name="behavior_executive" pkg="firefly_control" type="behavior_tree" output="screen">
+  <node name="behavior_executive" pkg="firefly_control" type="behavior_executive" output="screen">
     <param name="execute_target" type="double" value="10." />
   </node>
   <include file="$(find core_drone_interface)/launch/drone_interface_node.launch" pass_all_args="true" />

--- a/firefly_control/package.xml
+++ b/firefly_control/package.xml
@@ -49,12 +49,38 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>base</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>behavior_tree</build_depend>
+  <build_depend>behavior_tree_msgs</build_depend>
+  <build_depend>core_takeoff_landing_planner</build_depend>
+  <build_depend>core_trajectory_controller</build_depend>
+  <build_depend>core_drone_interface</build_depend>
+  <build_depend>core_trajectory_msgs</build_depend>
+
+  <build_export_depend>base</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>behavior_tree</build_export_depend>
+  <build_export_depend>behavior_tree_msgs</build_export_depend>
+  <build_export_depend>core_takeoff_landing_planner</build_export_depend>
+  <build_export_depend>core_trajectory_controller</build_export_depend>
+  <build_export_depend>core_drone_interface</build_export_depend>
+  <build_export_depend>core_trajectory_msgs</build_export_depend>
+
+  <exec_depend>base</exec_depend>
   <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>behavior_tree</exec_depend>
+  <exec_depend>behavior_tree_msgs</exec_depend>
+  <exec_depend>core_takeoff_landing_planner</exec_depend>
+  <exec_depend>core_trajectory_controller</exec_depend>
+  <exec_depend>core_drone_interface</exec_depend>
+  <exec_depend>core_trajectory_msgs</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/firefly_control/src/behavior_executive.cpp
+++ b/firefly_control/src/behavior_executive.cpp
@@ -1,0 +1,362 @@
+#include "behavior_executive.h"
+
+#include <base/BaseNode.h>
+
+#include <string>
+
+BehaviorExecutiveBehaviorTree::BehaviorExecutiveBehaviorTree(
+    std::string node_name)
+    : BaseNode(node_name) {}
+
+bool BehaviorExecutiveBehaviorTree::initialize() {
+  ros::NodeHandle* nh = get_node_handle();
+  ros::NodeHandle* pnh = get_private_node_handle();
+
+  // init conditions
+  takeoff_commanded_condition = new bt::Condition("Takeoff Commanded");
+  land_commanded_condition = new bt::Condition("Land Commanded");
+  pause_commanded_condition = new bt::Condition("Pause Commanded");
+  fixed_trajectory_commanded_condition =
+      new bt::Condition("Fixed Trajectory Commanded");
+  explore_commanded_condition =
+      new bt::Condition("Autonomously Explore Commanded");
+  autonomously_explore_commanded_condition =
+      new bt::Condition("Explore Commanded");
+  offboard_commanded_condition = new bt::Condition("Offboard Commanded");
+  arm_commanded_condition = new bt::Condition("Arm Commanded");
+  disarm_commanded_condition = new bt::Condition("Disarm Commanded");
+  rewind_commanded_condition = new bt::Condition("Rewind Commanded");
+  offboard_mode_condition = new bt::Condition("Offboard Mode");
+  armed_condition = new bt::Condition("Armed");
+  takeoff_complete_condition = new bt::Condition("Takeoff Complete");
+  landed_condition = new bt::Condition("Landed");
+  in_air_condition = new bt::Condition("In Air");
+
+  conditions.push_back(takeoff_commanded_condition);
+  conditions.push_back(land_commanded_condition);
+  conditions.push_back(pause_commanded_condition);
+  conditions.push_back(fixed_trajectory_commanded_condition);
+  conditions.push_back(explore_commanded_condition);
+  conditions.push_back(autonomously_explore_commanded_condition);
+  conditions.push_back(offboard_commanded_condition);
+  conditions.push_back(arm_commanded_condition);
+  conditions.push_back(disarm_commanded_condition);
+  conditions.push_back(rewind_commanded_condition);
+  conditions.push_back(offboard_mode_condition);
+  conditions.push_back(armed_condition);
+  conditions.push_back(takeoff_complete_condition);
+  conditions.push_back(landed_condition);
+  conditions.push_back(in_air_condition);
+
+  // init actions
+  takeoff_action = new bt::Action("Takeoff");
+  land_action = new bt::Action("Land");
+  pause_action = new bt::Action("Pause");
+  follow_fixed_trajectory_action = new bt::Action("Follow Fixed Trajectory");
+  explore_action = new bt::Action("Explore");
+  request_control_action = new bt::Action("Request Control");
+  arm_action = new bt::Action("Arm");
+  disarm_action = new bt::Action("Disarm");
+  rewind_action = new bt::Action("Rewind");
+
+  actions.push_back(takeoff_action);
+  actions.push_back(land_action);
+  actions.push_back(pause_action);
+  actions.push_back(follow_fixed_trajectory_action);
+  actions.push_back(explore_action);
+  actions.push_back(request_control_action);
+  actions.push_back(arm_action);
+  actions.push_back(disarm_action);
+  actions.push_back(rewind_action);
+
+  // init services
+  takeoff_landing_client =
+      nh->serviceClient<core_takeoff_landing_planner::TakeoffLandingCommand>(
+          "set_takeoff_landing_command");
+  trajectory_mode_client =
+      nh->serviceClient<core_trajectory_controller::TrajectoryMode>(
+          "set_trajectory_mode");
+  drone_command_client =
+      nh->serviceClient<core_drone_interface::DroneCommand>("drone_command");
+  x_reset_integrator_client =
+      nh->serviceClient<std_srvs::Empty>("pose_controller/x/reset_integrator");
+  y_reset_integrator_client =
+      nh->serviceClient<std_srvs::Empty>("pose_controller/y/reset_integrator");
+  z_reset_integrator_client =
+      nh->serviceClient<std_srvs::Empty>("pose_controller/z/reset_integrator");
+  yaw_reset_integrator_client = nh->serviceClient<std_srvs::Empty>(
+      "pose_controller/yaw/reset_integrator");
+  vx_reset_integrator_client = nh->serviceClient<std_srvs::Empty>(
+      "velocity_controller/vx/reset_integrator");
+  vy_reset_integrator_client = nh->serviceClient<std_srvs::Empty>(
+      "velocity_controller/vy/reset_integrator");
+  vz_reset_integrator_client = nh->serviceClient<std_srvs::Empty>(
+      "velocity_controller/vz/reset_integrator");
+  yawrate_reset_integrator_client = nh->serviceClient<std_srvs::Empty>(
+      "velocity_controller/yawrate/reset_integrator");
+
+  // init publishers
+  fixed_trajectory_pub = nh->advertise<core_trajectory_msgs::FixedTrajectory>(
+      "fixed_trajectory", 10);
+  in_air_pub = nh->advertise<std_msgs::Bool>("in_air", 1);
+
+  // init subscribers
+  behavior_tree_command_sub = nh->subscribe(
+      "behavior_tree_commands", 10,
+      &BehaviorExecutiveBehaviorTree::behavior_tree_command_callback, this);
+  takeoff_state_sub = nh->subscribe(
+      "takeoff_state", 10,
+      &BehaviorExecutiveBehaviorTree::takeoff_state_callback, this);
+  landing_state_sub = nh->subscribe(
+      "landing_state", 10,
+      &BehaviorExecutiveBehaviorTree::landing_state_callback, this);
+  fixed_trajectory_command_sub = nh->subscribe(
+      "fixed_trajectory_command", 10,
+      &BehaviorExecutiveBehaviorTree::fixed_trajectory_command_callback, this);
+  has_control_sub =
+      nh->subscribe("has_control", 10,
+                    &BehaviorExecutiveBehaviorTree::has_control_callback, this);
+  is_armed_sub = nh->subscribe(
+      "is_armed", 10, &BehaviorExecutiveBehaviorTree::is_armed_callback, this);
+
+  return true;
+}
+
+bool BehaviorExecutiveBehaviorTree::execute() {
+  // request control action
+  if (request_control_action->is_active()) {
+    if (request_control_action->active_has_changed()) {
+      core_drone_interface::DroneCommand drone_command_srv;
+      drone_command_srv.request.command =
+          core_drone_interface::DroneCommand::Request::REQUEST_CONTROL;
+      drone_command_client.call(drone_command_srv);
+
+      if (drone_command_srv.response.success) {
+        ROS_INFO("SUCCESS REQUEST CONTROL");
+        request_control_action->set_success();
+      } else {
+        ROS_INFO("FAILED REQUEST CONTROL");
+        request_control_action->set_failure();
+      }
+    }
+  }
+
+  // arm action
+  if (arm_action->is_active()) {
+    if (arm_action->active_has_changed()) {
+      // reset integrators before arming
+      std_srvs::Empty reset_srv;
+      x_reset_integrator_client.call(reset_srv);
+      y_reset_integrator_client.call(reset_srv);
+      z_reset_integrator_client.call(reset_srv);
+      yaw_reset_integrator_client.call(reset_srv);
+      vx_reset_integrator_client.call(reset_srv);
+      vy_reset_integrator_client.call(reset_srv);
+      vz_reset_integrator_client.call(reset_srv);
+      yawrate_reset_integrator_client.call(reset_srv);
+
+      // set takeoff and land conditions to false before arming
+      takeoff_complete_condition->set(false);
+      landed_condition->set(false);
+
+      // arm
+      core_drone_interface::DroneCommand drone_command_srv;
+      drone_command_srv.request.command =
+          core_drone_interface::DroneCommand::Request::ARM;
+      drone_command_client.call(drone_command_srv);
+
+      if (drone_command_srv.response.success) {
+        ROS_INFO("ARMED SUCCESS");
+        arm_action->set_success();
+      } else {
+        ROS_INFO("ARMED FAILURE");
+        arm_action->set_failure();
+      }
+
+      core_trajectory_controller::TrajectoryMode srv;
+      srv.request.mode =
+          core_trajectory_controller::TrajectoryMode::Request::PAUSE;
+      trajectory_mode_client.call(srv);
+    }
+  }
+
+  // disarm action
+  if (disarm_action->is_active()) {
+    if (disarm_action->active_has_changed()) {
+      in_air_condition->set(false);
+      core_drone_interface::DroneCommand drone_command_srv;
+      drone_command_srv.request.command =
+          core_drone_interface::DroneCommand::Request::DISARM;
+      drone_command_client.call(drone_command_srv);
+
+      if (drone_command_srv.response.success) {
+        ROS_INFO("DISARMED SUCCESS");
+        disarm_action->set_success();
+
+        // reset integrators after disarming
+        std_srvs::Empty reset_srv;
+        x_reset_integrator_client.call(reset_srv);
+        y_reset_integrator_client.call(reset_srv);
+        z_reset_integrator_client.call(reset_srv);
+        yaw_reset_integrator_client.call(reset_srv);
+        vx_reset_integrator_client.call(reset_srv);
+        vy_reset_integrator_client.call(reset_srv);
+        vz_reset_integrator_client.call(reset_srv);
+        yawrate_reset_integrator_client.call(reset_srv);
+
+        // set the tracking point to be at the robot's position
+        core_trajectory_controller::TrajectoryMode srv;
+        srv.request.mode =
+            core_trajectory_controller::TrajectoryMode::Request::ROBOT_POSE;
+        trajectory_mode_client.call(srv);
+      } else {
+        ROS_INFO("DISARMED FAILURE");
+        disarm_action->set_failure();
+      }
+    }
+  }
+
+  // takeoff action
+  if (takeoff_action->is_active()) {
+    takeoff_action->set_running();
+    in_air_condition->set(true);
+
+    if (takeoff_action->active_has_changed()) {
+      core_takeoff_landing_planner::TakeoffLandingCommand takeoff_srv;
+      takeoff_srv.request.command =
+          core_takeoff_landing_planner::TakeoffLandingCommand::Request::TAKEOFF;
+      takeoff_landing_client.call(takeoff_srv);
+    }
+
+    if (takeoff_state == "COMPLETE") {
+      takeoff_complete_condition->set(true);
+      takeoff_action->set_success();
+    }
+  }
+
+  // land action
+  if (land_action->is_active()) {
+    land_action->set_running();
+
+    if (land_action->active_has_changed()) {
+      core_takeoff_landing_planner::TakeoffLandingCommand land_srv;
+      land_srv.request.command =
+          core_takeoff_landing_planner::TakeoffLandingCommand::Request::LAND;
+      takeoff_landing_client.call(land_srv);
+    }
+
+    if (landing_state == "COMPLETE") {
+      landed_condition->set(true);
+      land_action->set_success();
+    }
+  }
+
+  // pause action
+  if (pause_action->is_active()) {
+    pause_action->set_running();
+
+    if (pause_action->active_has_changed()) {
+      core_trajectory_controller::TrajectoryMode srv;
+      srv.request.mode =
+          core_trajectory_controller::TrajectoryMode::Request::PAUSE;
+      trajectory_mode_client.call(srv);
+    }
+  }
+
+  // rewind action
+  if (rewind_action->is_active()) {
+    rewind_action->set_running();
+
+    if (rewind_action->active_has_changed()) {
+      core_trajectory_controller::TrajectoryMode srv;
+      srv.request.mode =
+          core_trajectory_controller::TrajectoryMode::Request::REWIND;
+      trajectory_mode_client.call(srv);
+    }
+  }
+
+  // follow fixed trajectory action
+  if (follow_fixed_trajectory_action->is_active()) {
+    follow_fixed_trajectory_action->set_running();
+
+    if (follow_fixed_trajectory_action->active_has_changed()) {
+      core_trajectory_controller::TrajectoryMode srv;
+      srv.request.mode =
+          core_trajectory_controller::TrajectoryMode::Request::TRACK;
+      trajectory_mode_client.call(srv);
+
+      fixed_trajectory_pub.publish(fixed_trajectory);
+    }
+  }
+
+  // explore action
+  if (explore_action->is_active()) {
+    explore_action->set_running();
+
+    if (explore_action->active_has_changed()) {
+      core_trajectory_controller::TrajectoryMode srv;
+      srv.request.mode =
+          core_trajectory_controller::TrajectoryMode::Request::SEGMENT;
+      trajectory_mode_client.call(srv);
+    }
+  }
+
+  for (int i = 0; i < conditions.size(); i++) conditions[i]->publish();
+  for (int i = 0; i < actions.size(); i++)
+    if (actions[i]->is_active()) actions[i]->publish();
+
+  std_msgs::Bool in_air_msg;
+  in_air_msg.data = in_air_condition->get();
+  in_air_pub.publish(in_air_msg);
+
+  return true;
+}
+
+void BehaviorExecutiveBehaviorTree::behavior_tree_command_callback(
+    behavior_tree_msgs::BehaviorTreeCommands msg) {
+  for (int i = 0; i < msg.commands.size(); i++) {
+    std::string condition_name = msg.commands[i].condition_name;
+    int status = msg.commands[i].status;
+
+    for (int j = 0; j < conditions.size(); j++) {
+      bt::Condition* condition = conditions[j];
+      if (condition_name == condition->get_label()) {
+        if (status == behavior_tree_msgs::Status::SUCCESS)
+          condition->set(true);
+        else if (status == behavior_tree_msgs::Status::FAILURE)
+          condition->set(false);
+      }
+    }
+  }
+}
+
+void BehaviorExecutiveBehaviorTree::takeoff_state_callback(
+    std_msgs::String msg) {
+  takeoff_state = msg.data;
+}
+
+void BehaviorExecutiveBehaviorTree::landing_state_callback(
+    std_msgs::String msg) {
+  landing_state = msg.data;
+}
+
+void BehaviorExecutiveBehaviorTree::fixed_trajectory_command_callback(
+    core_trajectory_msgs::FixedTrajectory msg) {
+  fixed_trajectory = msg;
+}
+
+void BehaviorExecutiveBehaviorTree::has_control_callback(std_msgs::Bool msg) {
+  offboard_mode_condition->set(msg.data);
+}
+
+void BehaviorExecutiveBehaviorTree::is_armed_callback(std_msgs::Bool msg) {
+  armed_condition->set(msg.data);
+}
+
+BehaviorExecutiveBehaviorTree::~BehaviorExecutiveBehaviorTree() {}
+
+BaseNode* BaseNode::get() {
+  BehaviorExecutiveBehaviorTree* core_behavior_executive =
+      new BehaviorExecutiveBehaviorTree("BehaviorExecutiveBehaviorTree");
+  return core_behavior_executive;
+}

--- a/firefly_control/src/behavior_executive.cpp
+++ b/firefly_control/src/behavior_executive.cpp
@@ -4,44 +4,35 @@
 
 #include <string>
 
-BehaviorExecutiveBehaviorTree::BehaviorExecutiveBehaviorTree(
-    std::string node_name)
+BehaviorExecutive::BehaviorExecutive(std::string node_name)
     : BaseNode(node_name) {}
 
-bool BehaviorExecutiveBehaviorTree::initialize() {
+bool BehaviorExecutive::initialize() {
   ros::NodeHandle* nh = get_node_handle();
   ros::NodeHandle* pnh = get_private_node_handle();
 
   // init conditions
+  request_control_commanded_condition =
+      new bt::Condition("Request Control Commanded");
   takeoff_commanded_condition = new bt::Condition("Takeoff Commanded");
   land_commanded_condition = new bt::Condition("Land Commanded");
-  pause_commanded_condition = new bt::Condition("Pause Commanded");
-  fixed_trajectory_commanded_condition =
-      new bt::Condition("Fixed Trajectory Commanded");
-  explore_commanded_condition =
-      new bt::Condition("Autonomously Explore Commanded");
-  autonomously_explore_commanded_condition =
-      new bt::Condition("Explore Commanded");
-  offboard_commanded_condition = new bt::Condition("Offboard Commanded");
   arm_commanded_condition = new bt::Condition("Arm Commanded");
   disarm_commanded_condition = new bt::Condition("Disarm Commanded");
-  rewind_commanded_condition = new bt::Condition("Rewind Commanded");
+  traj_control_commanded_condition =
+      new bt::Condition("Traj Control Commanded");
+
   offboard_mode_condition = new bt::Condition("Offboard Mode");
   armed_condition = new bt::Condition("Armed");
   takeoff_complete_condition = new bt::Condition("Takeoff Complete");
   landed_condition = new bt::Condition("Landed");
   in_air_condition = new bt::Condition("In Air");
 
+  conditions.push_back(request_control_commanded_condition);
   conditions.push_back(takeoff_commanded_condition);
   conditions.push_back(land_commanded_condition);
-  conditions.push_back(pause_commanded_condition);
-  conditions.push_back(fixed_trajectory_commanded_condition);
-  conditions.push_back(explore_commanded_condition);
-  conditions.push_back(autonomously_explore_commanded_condition);
-  conditions.push_back(offboard_commanded_condition);
   conditions.push_back(arm_commanded_condition);
   conditions.push_back(disarm_commanded_condition);
-  conditions.push_back(rewind_commanded_condition);
+  conditions.push_back(traj_control_commanded_condition);
   conditions.push_back(offboard_mode_condition);
   conditions.push_back(armed_condition);
   conditions.push_back(takeoff_complete_condition);
@@ -51,23 +42,15 @@ bool BehaviorExecutiveBehaviorTree::initialize() {
   // init actions
   takeoff_action = new bt::Action("Takeoff");
   land_action = new bt::Action("Land");
-  pause_action = new bt::Action("Pause");
-  follow_fixed_trajectory_action = new bt::Action("Follow Fixed Trajectory");
-  explore_action = new bt::Action("Explore");
   request_control_action = new bt::Action("Request Control");
   arm_action = new bt::Action("Arm");
   disarm_action = new bt::Action("Disarm");
-  rewind_action = new bt::Action("Rewind");
 
   actions.push_back(takeoff_action);
   actions.push_back(land_action);
-  actions.push_back(pause_action);
-  actions.push_back(follow_fixed_trajectory_action);
-  actions.push_back(explore_action);
   actions.push_back(request_control_action);
   actions.push_back(arm_action);
   actions.push_back(disarm_action);
-  actions.push_back(rewind_action);
 
   // init services
   takeoff_landing_client =
@@ -101,28 +84,25 @@ bool BehaviorExecutiveBehaviorTree::initialize() {
   in_air_pub = nh->advertise<std_msgs::Bool>("in_air", 1);
 
   // init subscribers
-  behavior_tree_command_sub = nh->subscribe(
-      "behavior_tree_commands", 10,
-      &BehaviorExecutiveBehaviorTree::behavior_tree_command_callback, this);
+  behavior_tree_command_sub =
+      nh->subscribe("behavior_tree_commands", 10,
+                    &BehaviorExecutive::behavior_tree_command_callback, this);
   takeoff_state_sub = nh->subscribe(
-      "takeoff_state", 10,
-      &BehaviorExecutiveBehaviorTree::takeoff_state_callback, this);
+      "takeoff_state", 10, &BehaviorExecutive::takeoff_state_callback, this);
   landing_state_sub = nh->subscribe(
-      "landing_state", 10,
-      &BehaviorExecutiveBehaviorTree::landing_state_callback, this);
+      "landing_state", 10, &BehaviorExecutive::landing_state_callback, this);
   fixed_trajectory_command_sub = nh->subscribe(
       "fixed_trajectory_command", 10,
-      &BehaviorExecutiveBehaviorTree::fixed_trajectory_command_callback, this);
-  has_control_sub =
-      nh->subscribe("has_control", 10,
-                    &BehaviorExecutiveBehaviorTree::has_control_callback, this);
-  is_armed_sub = nh->subscribe(
-      "is_armed", 10, &BehaviorExecutiveBehaviorTree::is_armed_callback, this);
+      &BehaviorExecutive::fixed_trajectory_command_callback, this);
+  has_control_sub = nh->subscribe(
+      "has_control", 10, &BehaviorExecutive::has_control_callback, this);
+  is_armed_sub = nh->subscribe("is_armed", 10,
+                               &BehaviorExecutive::is_armed_callback, this);
 
   return true;
 }
 
-bool BehaviorExecutiveBehaviorTree::execute() {
+bool BehaviorExecutive::execute() {
   // request control action
   if (request_control_action->is_active()) {
     if (request_control_action->active_has_changed()) {
@@ -251,56 +231,6 @@ bool BehaviorExecutiveBehaviorTree::execute() {
     }
   }
 
-  // pause action
-  if (pause_action->is_active()) {
-    pause_action->set_running();
-
-    if (pause_action->active_has_changed()) {
-      core_trajectory_controller::TrajectoryMode srv;
-      srv.request.mode =
-          core_trajectory_controller::TrajectoryMode::Request::PAUSE;
-      trajectory_mode_client.call(srv);
-    }
-  }
-
-  // rewind action
-  if (rewind_action->is_active()) {
-    rewind_action->set_running();
-
-    if (rewind_action->active_has_changed()) {
-      core_trajectory_controller::TrajectoryMode srv;
-      srv.request.mode =
-          core_trajectory_controller::TrajectoryMode::Request::REWIND;
-      trajectory_mode_client.call(srv);
-    }
-  }
-
-  // follow fixed trajectory action
-  if (follow_fixed_trajectory_action->is_active()) {
-    follow_fixed_trajectory_action->set_running();
-
-    if (follow_fixed_trajectory_action->active_has_changed()) {
-      core_trajectory_controller::TrajectoryMode srv;
-      srv.request.mode =
-          core_trajectory_controller::TrajectoryMode::Request::TRACK;
-      trajectory_mode_client.call(srv);
-
-      fixed_trajectory_pub.publish(fixed_trajectory);
-    }
-  }
-
-  // explore action
-  if (explore_action->is_active()) {
-    explore_action->set_running();
-
-    if (explore_action->active_has_changed()) {
-      core_trajectory_controller::TrajectoryMode srv;
-      srv.request.mode =
-          core_trajectory_controller::TrajectoryMode::Request::SEGMENT;
-      trajectory_mode_client.call(srv);
-    }
-  }
-
   for (int i = 0; i < conditions.size(); i++) conditions[i]->publish();
   for (int i = 0; i < actions.size(); i++)
     if (actions[i]->is_active()) actions[i]->publish();
@@ -312,8 +242,15 @@ bool BehaviorExecutiveBehaviorTree::execute() {
   return true;
 }
 
-void BehaviorExecutiveBehaviorTree::behavior_tree_command_callback(
+void BehaviorExecutive::behavior_tree_command_callback(
     behavior_tree_msgs::BehaviorTreeCommands msg) {
+  request_control_commanded_condition->set(false);
+  arm_commanded_condition->set(false);
+  disarm_commanded_condition->set(false);
+  takeoff_commanded_condition->set(false);
+  land_commanded_condition->set(false);
+  traj_control_commanded_condition->set(false);
+
   for (int i = 0; i < msg.commands.size(); i++) {
     std::string condition_name = msg.commands[i].condition_name;
     int status = msg.commands[i].status;
@@ -330,33 +267,31 @@ void BehaviorExecutiveBehaviorTree::behavior_tree_command_callback(
   }
 }
 
-void BehaviorExecutiveBehaviorTree::takeoff_state_callback(
-    std_msgs::String msg) {
+void BehaviorExecutive::takeoff_state_callback(std_msgs::String msg) {
   takeoff_state = msg.data;
 }
 
-void BehaviorExecutiveBehaviorTree::landing_state_callback(
-    std_msgs::String msg) {
+void BehaviorExecutive::landing_state_callback(std_msgs::String msg) {
   landing_state = msg.data;
 }
 
-void BehaviorExecutiveBehaviorTree::fixed_trajectory_command_callback(
+void BehaviorExecutive::fixed_trajectory_command_callback(
     core_trajectory_msgs::FixedTrajectory msg) {
   fixed_trajectory = msg;
 }
 
-void BehaviorExecutiveBehaviorTree::has_control_callback(std_msgs::Bool msg) {
+void BehaviorExecutive::has_control_callback(std_msgs::Bool msg) {
   offboard_mode_condition->set(msg.data);
 }
 
-void BehaviorExecutiveBehaviorTree::is_armed_callback(std_msgs::Bool msg) {
+void BehaviorExecutive::is_armed_callback(std_msgs::Bool msg) {
   armed_condition->set(msg.data);
 }
 
-BehaviorExecutiveBehaviorTree::~BehaviorExecutiveBehaviorTree() {}
+BehaviorExecutive::~BehaviorExecutive() {}
 
 BaseNode* BaseNode::get() {
-  BehaviorExecutiveBehaviorTree* core_behavior_executive =
-      new BehaviorExecutiveBehaviorTree("BehaviorExecutiveBehaviorTree");
+  BehaviorExecutive* core_behavior_executive =
+      new BehaviorExecutive("BehaviorExecutive");
   return core_behavior_executive;
 }

--- a/firefly_control/src/behavior_executive.cpp
+++ b/firefly_control/src/behavior_executive.cpp
@@ -103,7 +103,7 @@ bool BehaviorExecutive::initialize() {
 
 static core_trajectory_msgs::FixedTrajectory GetSquareFixedTraj() {
   core_trajectory_msgs::FixedTrajectory fixed_trajectory;
-  fixed_trajectory.type = "rectangle";
+  fixed_trajectory.type = "Rectangle";
   diagnostic_msgs::KeyValue attrib1;
   attrib1.key = "frame_id";
   attrib1.value = "world";
@@ -118,7 +118,7 @@ static core_trajectory_msgs::FixedTrajectory GetSquareFixedTraj() {
   attrib4.value = "30";
   diagnostic_msgs::KeyValue attrib5;
   attrib5.key = "velocity";
-  attrib5.value = "2";
+  attrib5.value = "0.5";
   fixed_trajectory.attributes = {attrib1, attrib2, attrib3, attrib4, attrib5};
   return fixed_trajectory;
 }

--- a/firefly_control/src/fixed_trajectory_generator.py
+++ b/firefly_control/src/fixed_trajectory_generator.py
@@ -1,0 +1,411 @@
+#!/usr/bin/python3
+import numpy as np
+import rospy
+from core_trajectory_msgs.msg import WaypointXYZVYaw
+from core_trajectory_msgs.msg import TrajectoryXYZVYaw
+from core_trajectory_msgs.msg import FixedTrajectory
+import copy
+
+def get_velocities(traj, velocity, max_acc):
+    v_prev = 0.
+
+    for i in range(len(traj.waypoints)):
+        j = (i+1) % len(traj.waypoints)
+        dx = traj.waypoints[j].position.x - traj.waypoints[i].position.x
+        dy = traj.waypoints[j].position.y - traj.waypoints[i].position.y
+
+        dist = np.sqrt(dx**2 + dy**2)
+        v_limit = np.sqrt(v_prev**2 + 2*max_acc*dist)
+        traj.waypoints[i].velocity = min(velocity, v_limit)
+        v_prev = traj.waypoints[i].velocity
+
+
+
+def get_racetrack_waypoints(attributes):#length, width, height):
+    frame_id = str(attributes['frame_id'])
+    length = float(attributes['length'])
+    width = float(attributes['width'])
+    height = float(attributes['height'])
+    velocity = float(attributes['velocity'])
+    max_acceleration = float(attributes['max_acceleration'])
+
+    traj = TrajectoryXYZVYaw()
+    traj.header.frame_id = frame_id
+    straightaway_length = length - width
+
+    # first straightaway
+    xs1 = np.linspace(0, straightaway_length, 20)
+    ys1 = np.zeros(xs1.shape)
+    yaws1 = np.zeros(xs1.shape)
+
+    # first turn
+    t = np.linspace(-np.pi/2, np.pi/2, 30)[1:-1]
+    xs2 = width/2.*np.cos(t) + straightaway_length
+    ys2 = width/2.*np.sin(t) + width/2.
+    xs2d = -width/2.*np.sin(t) # derivative of xs
+    ys2d = width/2.*np.cos(t) # derivative of ys
+    yaws2 = np.arctan2(ys2d, xs2d)
+
+    # second straightaway
+    xs3 = np.linspace(straightaway_length, 0, 20)
+    ys3 = width*np.ones(xs3.shape)
+    yaws3 = np.pi*np.ones(xs3.shape)
+
+    # second turn
+    t = np.linspace(np.pi/2, 3*np.pi/2, 30)[1:-1]
+    xs4 = width/2.*np.cos(t)
+    ys4 = width/2.*np.sin(t) + width/2.
+    yaws4 = yaws2 + np.pi
+
+    xs = np.hstack((xs1, xs2, xs3, xs4))
+    ys = np.hstack((ys1, ys2, ys3, ys4))
+    yaws = np.hstack((yaws1, yaws2, yaws3, yaws4))
+
+    now = rospy.Time.now()
+    for i in range(xs.shape[0]):
+        wp = WaypointXYZVYaw()
+        wp.position.x = xs[i]
+        wp.position.y = ys[i]
+        wp.position.z = height
+        wp.yaw = yaws[i]
+
+        traj.waypoints.append(wp)
+
+    get_velocities(traj, velocity, max_acceleration)
+
+    return traj
+
+
+def get_figure8_waypoints(attributes):#length, width, height):
+    frame_id = str(attributes['frame_id'])
+    length = float(attributes['length'])
+    width = float(attributes['width'])
+    height = float(attributes['height'])
+    velocity = float(attributes['velocity'])
+    max_acceleration = float(attributes['max_acceleration'])
+
+    traj = TrajectoryXYZVYaw()
+    traj.header.frame_id = frame_id
+    now = rospy.Time.now()
+
+    # figure 8 points
+    t = np.linspace(0, 2*np.pi, 100)
+    x = np.cos(t) * length - length
+    y = np.cos(t)*np.sin(t) * 2*width
+
+    # derivative of figure 8 curve, used to find yaw
+    xd = -np.sin(t) * length
+    yd = (np.cos(t)**2 - np.sin(t)**2) * 2*width
+
+    for i in range(t.shape[0] - 1):
+        x1 = x[i]
+        y1 = y[i]
+        x2 = x1 + xd[i]
+        y2 = y1 + yd[i]
+
+        yaw = np.arctan2(y2 - y1, x2 - x1)
+
+        wp = WaypointXYZVYaw()
+        wp.position.x = x1
+        wp.position.y = y1
+        wp.position.z = height
+        wp.yaw = yaw
+
+        traj.waypoints.append(wp)
+
+    get_velocities(traj, velocity, max_acceleration)
+
+    return traj
+
+def get_line_waypoints(attributes):#length, height):
+    frame_id = str(attributes['frame_id'])
+    length = float(attributes['length'])
+    height = float(attributes['height'])
+    velocity = float(attributes['velocity'])
+    max_acceleration = float(attributes['max_acceleration'])
+
+    traj = TrajectoryXYZVYaw()
+    traj.header.frame_id = frame_id
+
+    for y in np.arange(0, -length, -0.5):
+        wp = WaypointXYZVYaw()
+        wp.position.x = 0
+        wp.position.y = y
+        wp.position.z = height
+        wp.yaw = 0
+
+        traj.waypoints.append(wp)
+
+    get_velocities(traj, velocity, max_acceleration)
+
+    return traj
+
+def get_point_waypoints(attributes):#length, height):
+    frame_id = str(attributes['frame_id'])
+    x = float(attributes['x'])
+    y = float(attributes['y'])
+    height = float(attributes['height'])
+    velocity = float(attributes['velocity'])
+    max_acceleration = float(attributes['max_acceleration'])
+
+    traj = TrajectoryXYZVYaw()
+    traj.header.frame_id = frame_id
+
+    # add first point
+    wp = WaypointXYZVYaw()
+    wp.position.x = x
+    wp.position.y = y
+    wp.position.z = height
+    wp.yaw = 0
+
+    traj.waypoints.append(wp)
+
+    get_velocities(traj, velocity, max_acceleration)
+
+    return traj
+
+def get_box_waypoints(attributes):#length, height):
+    frame_id = str(attributes['frame_id'])
+    length = float(attributes['length'])
+    height = float(attributes['height'])
+    velocity = float(attributes['velocity'])
+    max_acceleration = float(attributes['max_acceleration'])
+
+    traj = TrajectoryXYZVYaw()
+    traj.header.frame_id = frame_id
+
+    wp1 = WaypointXYZVYaw()
+    wp1.position.x = 0.
+    wp1.position.y = 0.
+    wp1.position.z = height
+    wp1.yaw = 0
+    traj.waypoints.append(wp1)
+
+    wp2 = WaypointXYZVYaw()
+    wp2.position.x = length
+    wp2.position.y = 0.
+    wp2.position.z = height
+    wp2.yaw = 0
+    traj.waypoints.append(wp2)
+
+    wp3 = WaypointXYZVYaw()
+    wp3.position.x = length
+    wp3.position.y = 0.
+    wp3.position.z = height + height
+    wp3.yaw = 0
+    traj.waypoints.append(wp3)
+
+    wp4 = WaypointXYZVYaw()
+    wp4.position.x = 0.
+    wp4.position.y = 0.
+    wp4.position.z = height + height
+    wp4.yaw = 0
+    traj.waypoints.append(wp4)
+
+    return traj
+
+def get_vertical_lawnmower_waypoints(attributes):#length, width, height, velocity):
+    frame_id = str(attributes['frame_id'])
+    length = float(attributes['length'])
+    width = float(attributes['width'])
+    height = float(attributes['height'])
+    velocity = float(attributes['velocity'])
+
+    traj = TrajectoryXYZVYaw()
+    traj.header.frame_id = frame_id
+
+    for i in range(abs(int(height/width))):
+        wp1 = WaypointXYZVYaw()
+        wp1.position.x = 0
+        wp1.position.y = 0
+        wp1.position.z = np.sign(height)*(i+1)*width
+        wp1.yaw = 0
+        wp1.velocity = 0.1
+
+        wp1_ = WaypointXYZVYaw()
+        wp1_.position.x = 0
+        wp1_.position.y = 0.5
+        wp1_.position.z = np.sign(height)*(i+1)*width
+        wp1_.yaw = 0
+        wp1_.velocity = velocity
+
+        wp2 = WaypointXYZVYaw()
+        wp2.position.x = 0
+        wp2.position.y = length
+        wp2.position.z = np.sign(height)*(i+1)*width
+        wp2.yaw = 0
+        wp2.velocity = 0.1
+
+        wp2_ = WaypointXYZVYaw()
+        wp2_.position.x = 0
+        wp2_.position.y = length - 0.5
+        wp2_.position.z = np.sign(height)*(i+1)*width
+        wp2_.yaw = 0
+        wp2_.velocity = velocity
+
+        if i%2 == 0:
+            traj.waypoints.append(wp1)
+            wp1_slow = copy.deepcopy(wp1_)
+            wp1_slow.velocity = 0.1
+            traj.waypoints.append(wp1_slow)
+            traj.waypoints.append(wp1_)
+            traj.waypoints.append(wp2_)
+            traj.waypoints.append(wp2)
+        else:
+            traj.waypoints.append(wp2)
+            wp2_slow = copy.deepcopy(wp2_)
+            wp2_slow.velocity = 0.1
+            traj.waypoints.append(wp2_slow)
+            traj.waypoints.append(wp2_)
+            traj.waypoints.append(wp1_)
+            traj.waypoints.append(wp1)
+
+    wp = WaypointXYZVYaw()
+    wp.position.x = 0
+    wp.position.y = 0
+    wp.position.z = 0
+    wp.yaw = 0
+    wp.velocity = 0.5
+    traj.waypoints.append(wp)
+
+    return traj
+
+def get_circle_waypoints(attributes):#radius, velocity, frame_id):
+    frame_id = str(attributes['frame_id'])
+    radius = float(attributes['radius'])
+    velocity = float(attributes['velocity'])
+
+    traj = TrajectoryXYZVYaw()
+    traj.header.frame_id = frame_id
+    traj.header.stamp = rospy.Time.now()
+
+    wp0 = WaypointXYZVYaw()
+    wp0.position.x = 0
+    wp0.position.y = 0
+    wp0.position.z = 0
+    wp0.yaw = 0
+    wp0.velocity = velocity
+    traj.waypoints.append(wp0)
+
+    wp1 = WaypointXYZVYaw()
+    wp1.position.x = radius
+    wp1.position.y = 0
+    wp1.position.z = 0
+    wp1.yaw = 0
+    wp1.velocity = velocity
+    traj.waypoints.append(wp1)
+
+    for angle in np.arange(0, 2*np.pi, 10.*np.pi/180.):
+        wp = WaypointXYZVYaw()
+        wp.position.x = radius*np.cos(angle)
+        wp.position.y = radius*np.sin(angle)
+        wp.position.z = 0
+        wp.yaw = 0
+        wp.velocity = velocity
+        traj.waypoints.append(wp)
+
+    wp_end0 = WaypointXYZVYaw()
+    wp_end0.position.x = radius
+    wp_end0.position.y = 0
+    wp_end0.position.z = 0
+    wp_end0.yaw = 0
+    wp_end0.velocity = velocity
+    traj.waypoints.append(wp_end0)
+
+    wp_end1 = WaypointXYZVYaw()
+    wp_end1.position.x = 0
+    wp_end1.position.y = 0
+    wp_end1.position.z = 0
+    wp_end1.yaw = 0
+    wp_end1.velocity = velocity
+    traj.waypoints.append(wp_end1)
+
+    return traj
+
+def get_rectangle_waypoints(attributes):
+    frame_id = str(attributes['frame_id'])
+    length = float(attributes['length'])
+    width = float(attributes['width'])
+    height = float(attributes['height'])
+    velocity = float(attributes['velocity'])
+
+    traj = TrajectoryXYZVYaw()
+    traj.header.frame_id = frame_id
+
+    wp1 = WaypointXYZVYaw()
+    wp1.position.x = 0.
+    wp1.position.y = 0.
+    wp1.position.z = height
+    wp1.yaw = 0
+    wp1.velocity = velocity
+    traj.waypoints.append(wp1)
+
+    wp2 = WaypointXYZVYaw()
+    wp2.position.x = length
+    wp2.position.y = 0.
+    wp2.position.z = height
+    wp2.yaw = 0
+    wp2.velocity = velocity
+    traj.waypoints.append(wp2)
+
+    wp3 = WaypointXYZVYaw()
+    wp3.position.x = length
+    wp3.position.y = width
+    wp3.position.z = height
+    wp3.yaw = 0
+    wp3.velocity = velocity
+    traj.waypoints.append(wp3)
+
+    wp4 = WaypointXYZVYaw()
+    wp4.position.x = 0.
+    wp4.position.y = width
+    wp4.position.z = height
+    wp4.yaw = 0
+    wp4.velocity = velocity
+    traj.waypoints.append(wp4)
+
+    wp5 = WaypointXYZVYaw()
+    wp5.position.x = 0.
+    wp5.position.y = 0.
+    wp5.position.z = height
+    wp5.yaw = 0
+    wp5.velocity = velocity
+    traj.waypoints.append(wp5)
+
+    return traj
+
+
+def fixed_trajectory_callback(msg):
+    attributes = {}
+
+    for key_value in msg.attributes:
+        attributes[key_value.key] = key_value.value
+
+    trajectory_msg = None
+
+    if msg.type == 'Figure8':
+        trajectory_msg = get_figure8_waypoints(attributes)
+    elif msg.type == 'Circle':
+        trajectory_msg = get_circle_waypoints(attributes)
+    elif msg.type == 'Racetrack':
+        trajectory_msg = get_racetrack_waypoints(attributes)
+    elif msg.type == 'Line':
+        trajectory_msg = get_line_waypoints(attributes)
+    elif msg.type == 'Point':
+        trajectory_msg = get_point_waypoints(attributes)
+    elif msg.type == 'Rectangle':
+        trajectory_msg = get_rectangle_waypoints(attributes)
+
+    if trajectory_msg != None:
+        trajectory_track_pub.publish(trajectory_msg)
+    else:
+        print('No trajectory sent.')
+
+if __name__ == '__main__':
+    rospy.init_node('fixed_trajectory_generator')
+
+    fixed_trajectory_sub = rospy.Subscriber('fixed_trajectory', FixedTrajectory, fixed_trajectory_callback)
+
+    trajectory_track_pub = rospy.Publisher('trajectory_track', TrajectoryXYZVYaw, queue_size=1)
+
+    rospy.spin()

--- a/firefly_mapping/src/gcs_mapping.cpp
+++ b/firefly_mapping/src/gcs_mapping.cpp
@@ -138,11 +138,10 @@ private:
     }
 
     void publish_map_callback(const ros::TimerEvent& e) {
-        std::cout << mapped_bins << std::endl;
-        if (new_update) {
-            map_pub.publish(outputMap);
-            new_update = false;
-        }
+      if (new_update) {
+        map_pub.publish(outputMap);
+        new_update = false;
+      }
     }
 
     void clear(const std_msgs::Empty &empty_msg) {

--- a/firefly_telemetry/CMakeLists.txt
+++ b/firefly_telemetry/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
   message_generation
+  behavior_tree_msgs
 )
 
 add_service_files(

--- a/firefly_telemetry/package.xml
+++ b/firefly_telemetry/package.xml
@@ -52,12 +52,18 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>behavior_tree_msgs</build_depend>
+
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>behavior_tree_msgs</build_export_depend>
+
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>behavior_tree_msgs</exec_depend>
+
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -71,7 +71,7 @@ class OnboardTelemetry:
 
         self.set_local_pos_ref_pub = rospy.Publisher("set_local_pos_ref", Empty, queue_size=100)
         self.clear_map_pub = rospy.Publisher("clear_map", Empty, queue_size=100)
-        self.behavior_tree_commands_pub = rospy.Publisher("behavior_tree_commands", Empty, queue_size=100)
+        self.behavior_tree_commands_pub = rospy.Publisher("behavior_tree_commands", BehaviorTreeCommands, queue_size=100)
         self.kill_switch = rospy.Publisher("kill_switch", Empty, queue_size=10)
 
         rospy.Timer(rospy.Duration(0.5), self.pose_send_callback)
@@ -383,7 +383,7 @@ class OnboardTelemetry:
             command.status = Status.SUCCESS
             behavior_tree_commands.commands.append(command)
 
-        if not behavior_tree_commands.commands.empty():
+        if len(behavior_tree_commands.commands) > 0:
             self.behavior_tree_commands_pub.publish(behavior_tree_commands)
 
     def heartbeat_send_callback(self, event):


### PR DESCRIPTION
Add ability to takeoff, follow a square trajectory, and land by interfacing with the Air Lab Core Autonomy Stack. Modify the ground control station and onboard telemetry to support commands for requesting control, arming, taking off, following a preset trajectory, and landing. This has been tested to fully work in simulation. Flight test on 9/24 showed that sometimes, arming the drone fails. A future PR will fix this bug, but this bug does not affect the operating conditions of the drone when run with onboard_bringup.launch.