### PR TITLE
Integrate with Core Autonomy Stack and IPP Planner

### DIFF
--- a/firefly_bringup/config/rosconsole.config
+++ b/firefly_bringup/config/rosconsole.config
@@ -1,5 +1,4 @@
 # Add this to your .zshrc file: export ROSCONSOLE_CONFIG_FILE="$(rospack find firefly_bringup)/config/rosconsole.config"
 log4j.logger.ros=INFO
 log4j.logger.ros.roscpp.superdebug=WARN
-
-
+log4j.logger.ros.dji_sdk=DEBUG

--- a/firefly_bringup/launch/ca_bringup.launch
+++ b/firefly_bringup/launch/ca_bringup.launch
@@ -28,6 +28,8 @@
 
     <node pkg="firefly_control" type="ipp_plan_to_trajectory.py" name="ipp_plan_to_trajectory" output="screen"/>
 
+    <node pkg="planner_map_interfaces" type="pub_fixed_plan_request_on_demand.py" name="pub_fixed_plan_request_on_demand" output="screen"/>
+
   </group>
 
 

--- a/firefly_bringup/launch/ca_bringup.launch
+++ b/firefly_bringup/launch/ca_bringup.launch
@@ -34,7 +34,7 @@
   <arg name="planner" default="tigris" />
   <arg name="search" default="true" />
   <arg name="track" default="false" />
-  <arg name="rviz" default="true" />
+  <arg name="rviz" default="false" />
   <arg name="vis_while_planning" default="true" />
   <arg name="loglevel" default="debug" />
 

--- a/firefly_bringup/launch/ca_bringup.launch
+++ b/firefly_bringup/launch/ca_bringup.launch
@@ -26,6 +26,19 @@
     <!-- logging -->
     <!-- <node name="record" pkg="rosbag" type="record" args="-a -o ~/bags/dji" /> -->
 
+    <node pkg="firefly_control" type="ipp_plan_to_trajectory.py" name="ipp_plan_to_trajectory" output="screen"/>
+
   </group>
+
+
+  <arg name="planner" default="tigris" />
+  <arg name="search" default="true" />
+  <arg name="track" default="false" />
+  <arg name="rviz" default="true" />
+  <arg name="vis_while_planning" default="true" />
+  <arg name="loglevel" default="debug" />
+
+  <include file="$(find onr_ipp)/launch/sim_belief_and_plan.launch" pass_all_args="true" />
+
 
 </launch>

--- a/firefly_bringup/launch/onboard_bringup.launch
+++ b/firefly_bringup/launch/onboard_bringup.launch
@@ -30,6 +30,7 @@
         <include file="$(find core_central)/launch/dji/sim/dji_sim_control.launch" pass_all_args="true" />
         <include file="$(find firefly_control)/launch/autonomy.launch" pass_all_args="true" />
         <node pkg="firefly_control" type="ipp_plan_to_trajectory.py" name="ipp_plan_to_trajectory" output="screen" />
+        <node pkg="planner_map_interfaces" type="pub_fixed_plan_request_on_demand.py" name="pub_fixed_plan_request_on_demand" output="screen"/>
       </group>
     </group>
   </group>

--- a/firefly_bringup/launch/onboard_bringup.launch
+++ b/firefly_bringup/launch/onboard_bringup.launch
@@ -4,36 +4,41 @@
   
   <arg name="replay_mode" default="false"/>
   <arg name="open_flir" default="false"/>
-  <arg name="continuous" default="true"/>
-  <arg name="wp_following" default="false"/>
-  <arg name="use_rtk_offset" default="false"/>
-  <arg name="lat0rtk" default="40.4417346"/>
-  <arg name="lon0rtk" default="-79.9441409"/>
+  <arg name="continuous" default="true" />
   <arg name="threshold" default="50"/>
+  <arg name="robot_name" default="uav1" />
+  <arg name="drone_interface" default="DJIInterface" />
+  <arg name="run_ca_stack" default="true" />
 
+  <group ns="$(arg robot_name)">
+    <node pkg="firefly_mapping" type="onboard_mapping" name="onboard_mapping" output="screen" />
+    <node pkg="firefly_telemetry" type="onboard_telemetry.py" name="onboard_telemetry" output="screen" />
+    <node pkg="firefly_perception" type="firefly_perception" name="firefly_perception" output="screen">
+      <param name="threshold" value="$(arg threshold)" />
+      <param name="continuous" value="$(arg continuous)" />
+    </node>
+    <node pkg="firefly_bringup" type="pcb_interface.py" name="pcb_interface" output="screen" />
 
-  <node pkg="firefly_mapping" type="onboard_mapping" name="onboard_mapping" output="screen"/>
-  <node pkg="firefly_telemetry" type="onboard_telemetry.py" name="onboard_telemetry" output="screen"/>
-  <node pkg="firefly_perception" type="firefly_perception" name="firefly_perception" output="screen">
-    <param name="threshold" value="$(arg threshold)"/>
-    <param name="continuous" value="$(arg continuous)"/>
-  </node>  
+    <group unless="$(arg replay_mode)">
+      <include file="$(find dji_sdk)/launch/sdk.launch" />
+      <include file="$(find flir_ros_sync)/launch/example/flir_ros.launch" if="$(arg open_flir)" />
+      <include file="$(find seek_driver)/launch/seek_driver.launch" />
+      <include file="$(find core_central)/launch/dji/sim/dji_sim_state_estimation.launch" pass_all_args="true" />
+      <node pkg="tf" type="static_transform_publisher" name="base_to_thermal_camera_link" args="0.0543145 0.041098 -0.27658746 -1.5707963 0 3.14159 $(arg robot_name)/base_link $(arg robot_name)/thermal/camera_link 100" />
 
-  <include file="$(find dji_sdk)/launch/sdk.launch" unless="$(arg replay_mode)"/>
-  <include file="$(find flir_ros_sync)/launch/example/flir_ros.launch" if="$(arg open_flir)"/>
-  <include file="$(find seek_driver)/launch/seek_driver.launch" unless="$(arg replay_mode)"/>
+      <group if="$(arg run_ca_stack)">
+        <include file="$(find core_central)/launch/dji/sim/dji_sim_control.launch" pass_all_args="true" />
+        <include file="$(find firefly_control)/launch/autonomy.launch" pass_all_args="true" />
+        <node pkg="firefly_control" type="ipp_plan_to_trajectory.py" name="ipp_plan_to_trajectory" output="screen" />
+      </group>
+    </group>
+  </group>
 
-  <node pkg="tf" type="static_transform_publisher" name="base_to_thermal_camera_link" args="0.0543145 0.041098 -0.27658746 -1.5707963 0 3.14159 base_link thermal/camera_link 100"/>
-
-  <node pkg="firefly_bringup" type="gps_to_local_enu.py" name="gps_to_local_enu" if="$(arg use_rtk_offset)" output="screen">
-    <param name="lat0rtk" value="$(arg lat0rtk)"/>
-    <param name="lon0rtk" value="$(arg lon0rtk)"/>
-  </node>
-
-  <node pkg="firefly_bringup" type="gps_to_local_enu.py" name="gps_to_local_enu" unless="$(arg use_rtk_offset)" output="screen"/>
-
-  <node pkg="firefly_bringup" type="pcb_interface.py" name="pcb_interface" output="screen"/>
-
-  <node pkg="firefly_control" type="simple_waypoint_test" name="simple_waypoint_test" if="$(arg wp_following)" output="screen"/>
-
+  <arg name="planner" default="tigris" />
+  <arg name="search" default="true" />
+  <arg name="track" default="false" />
+  <arg name="rviz" default="false" />
+  <arg name="vis_while_planning" default="true" />
+  <arg name="loglevel" default="debug" />
+  <include file="$(find onr_ipp)/launch/sim_belief_and_plan.launch" pass_all_args="true" />
 </launch>

--- a/firefly_bringup/scripts/run_rgb.bash
+++ b/firefly_bringup/scripts/run_rgb.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+gst-launch-1.0 -e nvarguscamerasrc sensor-id=0 ! tee name=t \
+t. ! queue ! "video/x-raw(memory:NVMM),width=1280,height=720,framerate=40/1" ! nvvidconv flip-method=2 ! xvimagesink

--- a/firefly_control/config/firefly.tree
+++ b/firefly_control/config/firefly.tree
@@ -1,15 +1,10 @@
 ?
 	->
 		(Disarm Commanded)
-		?
-			<!>
-				(Armed)
-			[Disarm]
+		[Disarm]
 	->
 		(Request Control Commanded)
-		?
-			(Offboard Mode)
-			[Request Control]
+		[Request Control]
 	->
 		(Takeoff Commanded)
 		?
@@ -22,18 +17,13 @@
 			[Land]
 	->
 		(Arm Commanded)
-		?
-			(Armed)
-			[Arm]
+		[Arm]
 	->	
 		(Traj Control Commanded)
-		?
-			[Traj Control]
+		[Traj Control]
 	->	
 		(Coverage Planner Commanded)
-		?
-			[Coverage Planner]
+		[Coverage Planner]
 	->	
 		(IPP Planner Commanded)
-		?
-			[IPP Planner]
+		[IPP Planner]

--- a/firefly_control/include/behavior_executive.h
+++ b/firefly_control/include/behavior_executive.h
@@ -13,6 +13,7 @@
 #include <std_msgs/Bool.h>
 #include <std_msgs/String.h>
 #include <std_srvs/Empty.h>
+#include <std_msgs/Empty.h>
 
 #include <string>
 
@@ -62,6 +63,7 @@ class BehaviorExecutive : public BaseNode {
   // publishers
   ros::Publisher fixed_trajectory_pub;
   ros::Publisher in_air_pub;
+  ros::Publisher generate_ipp_plan_request_pub;
 
   // subscribers
   ros::Subscriber behavior_tree_command_sub;

--- a/firefly_control/src/behavior_executive.cpp
+++ b/firefly_control/src/behavior_executive.cpp
@@ -128,7 +128,7 @@ static core_trajectory_msgs::FixedTrajectory GetSquareFixedTraj() {
   attrib4.value = "30";
   diagnostic_msgs::KeyValue attrib5;
   attrib5.key = "velocity";
-  attrib5.value = "0.5";
+  attrib5.value = "3.0";
   fixed_trajectory.attributes = {attrib1, attrib2, attrib3, attrib4, attrib5};
   return fixed_trajectory;
 }
@@ -150,7 +150,7 @@ static core_trajectory_msgs::FixedTrajectory GetLawnmowerTraj() {
   attrib4.value = "30";
   diagnostic_msgs::KeyValue attrib5;
   attrib5.key = "velocity";
-  attrib5.value = "0.5";
+  attrib5.value = "3.0";
   diagnostic_msgs::KeyValue attrib6;
   attrib6.key = "stepover_dist";
   attrib6.value = "5.0";

--- a/firefly_control/src/fixed_trajectory_generator.py
+++ b/firefly_control/src/fixed_trajectory_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.6
+#!/usr/bin/python3
 import numpy as np
 import rospy
 from core_trajectory_msgs.msg import WaypointXYZVYaw

--- a/firefly_control/src/fixed_trajectory_generator.py
+++ b/firefly_control/src/fixed_trajectory_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python3.6
 import numpy as np
 import rospy
 from core_trajectory_msgs.msg import WaypointXYZVYaw

--- a/firefly_control/src/ipp_plan_to_trajectory.py
+++ b/firefly_control/src/ipp_plan_to_trajectory.py
@@ -11,6 +11,14 @@ def ipp_plan_callback(ipp_plan):
     trajectory_msg.header = ipp_plan.header
     trajectory_msg.header.frame_id = "/uav1/map"
 
+    wp1 = WaypointXYZVYaw()
+    wp1.position.x = 0
+    wp1.position.y = 0
+    wp1.position.z = 30
+    wp1.yaw = 0
+    wp1.velocity = 0.5
+    trajectory_msg.waypoints.append(wp1)
+
     for wp in ipp_plan.plan:
         output_wp = WaypointXYZVYaw()
         output_wp.position.x = wp.position.position.x
@@ -26,6 +34,14 @@ def ipp_plan_callback(ipp_plan):
         output_wp.velocity = 0.5
 
         trajectory_msg.waypoints.append(output_wp)
+    
+    wp1 = WaypointXYZVYaw()
+    wp1.position.x = 0
+    wp1.position.y = 0
+    wp1.position.z = 30
+    wp1.yaw = 0
+    wp1.velocity = 0.5
+    trajectory_msg.waypoints.append(wp1)
 
     trajectory_track_pub.publish(trajectory_msg)
 

--- a/firefly_control/src/ipp_plan_to_trajectory.py
+++ b/firefly_control/src/ipp_plan_to_trajectory.py
@@ -16,7 +16,7 @@ def ipp_plan_callback(ipp_plan):
     wp1.position.y = 0
     wp1.position.z = 30
     wp1.yaw = 0
-    wp1.velocity = 0.5
+    wp1.velocity = 3.0
     trajectory_msg.waypoints.append(wp1)
 
     for wp in ipp_plan.plan:
@@ -31,7 +31,7 @@ def ipp_plan_callback(ipp_plan):
         )
         output_wp.yaw = yaw
 
-        output_wp.velocity = 0.5
+        output_wp.velocity = 3.0
 
         trajectory_msg.waypoints.append(output_wp)
     
@@ -40,7 +40,7 @@ def ipp_plan_callback(ipp_plan):
     wp1.position.y = 0
     wp1.position.z = 30
     wp1.yaw = 0
-    wp1.velocity = 0.5
+    wp1.velocity = 3.0
     trajectory_msg.waypoints.append(wp1)
 
     trajectory_track_pub.publish(trajectory_msg)

--- a/firefly_control/src/ipp_plan_to_trajectory.py
+++ b/firefly_control/src/ipp_plan_to_trajectory.py
@@ -1,19 +1,21 @@
+#!/usr/bin/python2
+
 import rospy
 from planner_map_interfaces.msg import Plan, Waypoint
 from core_trajectory_msgs.msg import TrajectoryXYZVYaw, WaypointXYZVYaw
 from tf.transformations import euler_from_quaternion
 
 
-def ipp_plan_callback(ipp_plan: Plan):
-    trajectory_msg = TrajectoryXYZVYaw
+def ipp_plan_callback(ipp_plan):
+    trajectory_msg = TrajectoryXYZVYaw()
     trajectory_msg.header = ipp_plan.header
+    trajectory_msg.header.frame_id = "/uav1/map"
 
     for wp in ipp_plan.plan:
-        wp = Waypoint()
         output_wp = WaypointXYZVYaw()
-        output_wp.position.x = wp.position.x
-        output_wp.position.y = wp.position.y
-        output_wp.position.z = wp.position.z
+        output_wp.position.x = wp.position.position.x
+        output_wp.position.y = wp.position.position.y
+        output_wp.position.z = wp.position.position.z
 
         orientation = wp.position.orientation
         (_, _, yaw) = euler_from_quaternion(
@@ -21,7 +23,7 @@ def ipp_plan_callback(ipp_plan: Plan):
         )
         output_wp.yaw = yaw
 
-        output_wp.velocity = wp.command_speed
+        output_wp.velocity = 0.5
 
         trajectory_msg.waypoints.append(output_wp)
 

--- a/firefly_control/src/ipp_plan_to_trajectory.py
+++ b/firefly_control/src/ipp_plan_to_trajectory.py
@@ -1,0 +1,37 @@
+import rospy
+from planner_map_interfaces.msg import Plan, Waypoint
+from core_trajectory_msgs.msg import TrajectoryXYZVYaw, WaypointXYZVYaw
+from tf.transformations import euler_from_quaternion
+
+
+def ipp_plan_callback(ipp_plan: Plan):
+    trajectory_msg = TrajectoryXYZVYaw
+    trajectory_msg.header = ipp_plan.header
+
+    for wp in ipp_plan.plan:
+        wp = Waypoint()
+        output_wp = WaypointXYZVYaw()
+        output_wp.position.x = wp.position.x
+        output_wp.position.y = wp.position.y
+        output_wp.position.z = wp.position.z
+
+        orientation = wp.position.orientation
+        (_, _, yaw) = euler_from_quaternion(
+            [orientation.x, orientation.y, orientation.z, orientation.w]
+        )
+        output_wp.yaw = yaw
+
+        output_wp.velocity = wp.command_speed
+
+        trajectory_msg.waypoints.append(output_wp)
+
+    trajectory_track_pub.publish(trajectory_msg)
+
+
+if __name__ == "__main__":
+    rospy.init_node("ipp_plan_to_traj_xyzv_yaw", anonymous=True)
+    trajectory_track_pub = rospy.Publisher(
+        "trajectory_track", TrajectoryXYZVYaw, queue_size=1
+    )
+    rospy.Subscriber("/global_path", Plan, ipp_plan_callback)
+    rospy.spin()

--- a/firefly_mapping/src/onboard_mapping.cpp
+++ b/firefly_mapping/src/onboard_mapping.cpp
@@ -38,7 +38,7 @@ public:
                  0.0,     1.0/fy, -cy/fy,
                  0.0,     0.0,     1.0;
 
-        outputMap.header.frame_id = "world";
+        outputMap.header.frame_id = "uav1/map";
         outputMap.info.resolution = 0.5;
         outputMap.info.width = 400; //Number of Cells
         outputMap.info.height = 400; //Number of Cells

--- a/firefly_perception/CMakeLists.txt
+++ b/firefly_perception/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 find_package(
-  OpenCV 3.2 
+  OpenCV
 )
 catkin_package(
 #  INCLUDE_DIRS include

--- a/firefly_perception/src/firefly_perception.cpp
+++ b/firefly_perception/src/firefly_perception.cpp
@@ -84,9 +84,8 @@ public:
                 cv::imshow("Thresholded Image", cv_img.image);
             }
 
-
-            listener.lookupTransform("world", "thermal/camera_link",
-                                         ros::Time(0), img_transform);
+            listener.lookupTransform("/uav1/map", "/uav1/thermal/camera_link",
+                                     ros::Time(0), img_transform);
 
             img_with_tf_ready = true;
 

--- a/firefly_perception/src/firefly_perception.cpp
+++ b/firefly_perception/src/firefly_perception.cpp
@@ -49,9 +49,9 @@ public:
     ThermalImageReader()
             : it_(nh_), private_nh_("~")
     {
-        image_sub_thresh = it_.subscribe("/seek_camera/temperatureImageCelcius", 1,
+        image_sub_thresh = it_.subscribe("seek_camera/temperatureImageCelcius", 1,
                                    &ThermalImageReader::imageCbThresh, this);
-        image_sub_gray = it_.subscribe("/seek_camera/displayImage", 1,
+        image_sub_gray = it_.subscribe("seek_camera/displayImage", 1,
                                    &ThermalImageReader::imageCbGray, this);
 
         img_extract_sub = nh_.subscribe("extract_frame",1,  &ThermalImageReader::img_extract_cb,  this);
@@ -84,7 +84,7 @@ public:
                 cv::imshow("Thresholded Image", cv_img.image);
             }
 
-            listener.lookupTransform("/uav1/map", "/uav1/thermal/camera_link",
+            listener.lookupTransform("uav1/map", "uav1/thermal/camera_link",
                                      ros::Time(0), img_transform);
 
             img_with_tf_ready = true;

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -65,9 +65,9 @@ class OnboardTelemetry:
         rospy.Subscriber("new_fire_bins", Int32MultiArray, self.new_fire_bins_callback)
         rospy.Subscriber("new_no_fire_bins", Int32MultiArray, self.new_no_fire_bins_callback)
         rospy.Subscriber("init_to_no_fire_with_pose_bins", Pose, self.init_to_no_fire_with_pose_callback)
-        rospy.Subscriber("/seek_camera/isHealthy", Bool, self.camera_health_callback)
-        rospy.Subscriber("/dji_sdk/gps_position", NavSatFix , self.get_altitude_callback)
-        rospy.Subscriber("/dji_sdk/battery_state", BatteryState, self.battery_health_callback)
+        rospy.Subscriber("seek_camera/isHealthy", Bool, self.camera_health_callback)
+        rospy.Subscriber("dji_sdk/gps_position", NavSatFix , self.get_altitude_callback)
+        rospy.Subscriber("dji_sdk/battery_state", BatteryState, self.battery_health_callback)
         rospy.Subscriber("onboard_temperature", Float32, self.onboard_temperature_callback)
 
         self.set_local_pos_ref_pub = rospy.Publisher("set_local_pos_ref", Empty, queue_size=100)
@@ -232,7 +232,7 @@ class OnboardTelemetry:
             return
 
         try:
-            transform = self.tfBuffer.lookup_transform('/uav1/base_link', '/uav1/map', rospy.Time(0))
+            transform = self.tfBuffer.lookup_transform('uav1/base_link', 'uav1/map', rospy.Time(0))
             x = transform.transform.translation.x
             y = transform.transform.translation.y
             z = transform.transform.translation.z

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -23,7 +23,7 @@ import os
 from threading import Lock
 import tf2_ros
 import struct
-from firefly_telemetry.srv import SetLocalPosRef
+# from firefly_telemetry.srv import SetLocalPosRef
 import time
 import serial
 import datetime
@@ -31,6 +31,7 @@ from geometry_msgs.msg import Pose
 from std_msgs.msg import Bool, Float32
 from sensor_msgs.msg import BatteryState, NavSatFix
 from behavior_tree_msgs.msg import BehaviorTreeCommand, BehaviorTreeCommands, Status
+from dji_sdk.srv import SetLocalPosRef
 
 os.environ['MAVLINK20'] = '1'
 
@@ -311,11 +312,12 @@ class OnboardTelemetry:
             self.clear_map_pub.publish(Empty())
         elif msg['mavpackettype'] == 'FIREFLY_SET_LOCAL_POS_REF':
             self.clear_map_pub.publish(Empty())
-            rospy.wait_for_service('set_local_pos_ref', timeout=0.1)
+            rospy.wait_for_service('dji_sdk/set_local_pos_ref', timeout=0.1)
             try:
-                set_local_pos_ref = rospy.ServiceProxy('set_local_pos_ref', SetLocalPosRef)
+                set_local_pos_ref = rospy.ServiceProxy('dji_sdk/set_local_pos_ref', SetLocalPosRef)
                 response = set_local_pos_ref()
-                self.connection.mav.firefly_local_pos_ref_send(response.latitude, response.longitude, response.altitude)
+                # self.connection.mav.firefly_local_pos_ref_send(response.latitude, response.longitude, response.altitude)
+                self.connection.mav.firefly_local_pos_ref_send(0, 0, 0)
             except rospy.ServiceException as e:
                 rospy.logerr("Service call failed: %s" % e)            
         elif msg['mavpackettype'] == 'FIREFLY_KILL':

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -231,7 +231,7 @@ class OnboardTelemetry:
             return
 
         try:
-            transform = self.tfBuffer.lookup_transform('base_link', 'world', rospy.Time(0))
+            transform = self.tfBuffer.lookup_transform('/uav1/base_link', '/uav1/map', rospy.Time(0))
             x = transform.transform.translation.x
             y = transform.transform.translation.y
             z = transform.transform.translation.z


### PR DESCRIPTION
Add core autonomy stack to onboard_bringup. Modify firefly stack to use uav1/map to base_link transform from core autonomy stack rather than generating the world to base_link tf frame using gps_to_local_enu.py. Allow onboard telemetry to call set_local_pos_ref service offered by dji_sdk node. Create node to convert from a planner_map_interfaces.msg.Plan generated by the IPP planner to a Trajectory XYZVYaw message used by the core autonomy stack trajectory controller. Firefly.tree has been modified such that commands like arm and request control can be called again without blocking due to a offboard_mode and armed condition. This is because the offboard_mode and armed conditions, updated based on the dji_interface, may be in a wrong state after a telemetry override. 