### PR TITLE
Update udev rules for new RFD900 radio

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ If you face a build error saying that "common is required but boost was not foun
 
 Note that the sdk.launch file in the dji_sdk package expects the DJI_SDK_APP_ID and DJI_SDK_ENC_KEY to be set.
 
-Install the udev rules by running the following command.
+Install the udev rules on the onboard computer by running the following command.
 
-    sudo cp firefly_bringup/99-firefly.rules /etc/udev/rules.d
+    sudo cp firefly_bringup/99-firefly-onboard.rules /etc/udev/rules.d
+    sudo udevadm control --reload-rules && udevadm trigger
+
+Install the udev rules on the ground control station by running the following command.
+
+    sudo cp firefly_bringup/99-firefly-gcs.rules /etc/udev/rules.d
+    sudo udevadm control --reload-rules && udevadm trigger
+

--- a/firefly_bringup/99-firefly-gcs.rules
+++ b/firefly_bringup/99-firefly-gcs.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tty", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ACTION=="add", MODE="666", SYMLINK+="mavlink"

--- a/firefly_bringup/99-firefly-onboard.rules
+++ b/firefly_bringup/99-firefly-onboard.rules
@@ -1,0 +1,3 @@
+SUBSYSTEM=="tty", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{product}=="USB <-> Serial", ACTION=="add", MODE="666", SYMLINK+="dji"
+SUBSYSTEM=="tty", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ATTRS{product}=="FT232R USB UART", ACTION=="add", MODE="666", SYMLINK+="mavlink"
+SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0043", ACTION=="add", MODE="666", SYMLINK+="temp_pcb"

--- a/firefly_bringup/99-firefly.rules
+++ b/firefly_bringup/99-firefly.rules
@@ -1,4 +1,0 @@
-SUBSYSTEM=="tty", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", ACTION=="add", MODE="666", SYMLINK+="dji"
-SUBSYSTEM=="tty", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ACTION=="add", MODE="666", SYMLINK+="mavlink"
-SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0043", ACTION=="add", MODE="666", SYMLINK+="temp_pcb"
-


### PR DESCRIPTION
Update the udev rules so that the onboard computer can disambiguate between the rfd900 and dji sdk interface. Add separate set of udev rules for the ground control station since the attributes for the GCS radio are slightly different. Note, these rules may need to be changed if the radio usb to ftdi cable is changed. These rules have been tested onboard and on the GCS.