### PR TITLE
Overhaul behavior executive and behavior tree

### DIFF
--- a/firefly_control/config/firefly.tree
+++ b/firefly_control/config/firefly.tree
@@ -1,29 +1,48 @@
 ?
+	-> 
+		(Reset Behavior Tree Commanded)
+		[Reset Behavior Tree]
 	->
 		(Disarm Commanded)
 		[Disarm]
 	->
-		(Request Control Commanded)
-		[Request Control]
-	->
-		(Takeoff Commanded)
-		?
-			(Takeoff Complete)
-			[Takeoff]
-	->
-		(Land Commanded)
-		?
-			(Landed)
-			[Land]
-	->
 		(Arm Commanded)
 		[Arm]
-	->	
-		(Traj Control Commanded)
-		[Traj Control]
-	->	
-		(Coverage Planner Commanded)
-		[Coverage Planner]
-	->	
-		(IPP Planner Commanded)
-		[IPP Planner]
+	->
+		(Set Local Position Reference Commanded)
+		[Set Local Position Reference]
+	->
+		(Local Position Reference Set)
+		?
+			->
+				(Request Control Commanded)
+				[Request Control]
+			->	
+				(Get Initial IPP Plan Commanded)
+				[Idle and Get Initial IPP Plan]
+			->
+				(Have Control)
+				?
+					-> 
+						(Autonomy Mode Is Idle)
+						[Autonomy Idle]
+					->
+						(Autonomy Mode Is Takeoff)
+						?
+							(Takeoff Complete)
+							[Autonomy Takeoff]
+					->
+						(Autonomy Mode Is Land)
+						?
+							(Landed)
+							[Autonomy Land]
+					->	
+						(Autonomy Mode Is Traj Control)
+						[Autonomy Traj Control]
+					->	
+						(Autonomy Mode Is Coverage Planner)
+						[Autonomy Coverage Planner]
+					->
+						(Autonomy Mode Is IPP Planner)
+						(Got Initial IPP Plan)
+						[Autonomy IPP Planner]

--- a/firefly_control/include/behavior_executive.h
+++ b/firefly_control/include/behavior_executive.h
@@ -10,10 +10,11 @@
 #include <core_trajectory_controller/TrajectoryMode.h>
 #include <core_trajectory_msgs/FixedTrajectory.h>
 #include <diagnostic_msgs/KeyValue.h>
+#include <dji_sdk/SetLocalPosRef.h>
 #include <std_msgs/Bool.h>
+#include <std_msgs/Empty.h>
 #include <std_msgs/String.h>
 #include <std_srvs/Empty.h>
-#include <std_msgs/Empty.h>
 
 #include <string>
 
@@ -24,32 +25,41 @@ class BehaviorExecutive : public BaseNode {
 
   // conditions
   std::vector<bt::Condition *> conditions;
-
-  bt::Condition *request_control_commanded_condition;
-  bt::Condition *arm_commanded_condition;
+  std::vector<bt::Condition *> autonomy_mode_conditions;
+  bt::Condition *reset_bt_commanded_condition;
   bt::Condition *disarm_commanded_condition;
-  bt::Condition *takeoff_commanded_condition;
-  bt::Condition *land_commanded_condition;
-  bt::Condition *traj_control_commanded_condition;
-  bt::Condition *coverage_planner_commanded_condition;
-  bt::Condition *ipp_planner_commanded_condition;
-
+  bt::Condition *arm_commanded_condition;
+  bt::Condition *set_local_pos_ref_commanded_condition;
+  bt::Condition *local_pos_ref_set_condition;
+  bt::Condition *request_control_commanded_condition;
+  bt::Condition *have_control_condition;
+  bt::Condition *autonomy_idle_condition;
+  bt::Condition *autonomy_takeoff_condition;
+  bt::Condition *autonomy_land_condition;
+  bt::Condition *autonomy_traj_control_condition;
+  bt::Condition *autonomy_coverage_planner_condition;
+  bt::Condition *autonomy_ipp_planner_condition;
   bt::Condition *offboard_mode_condition;
-  bt::Condition *armed_condition;
   bt::Condition *takeoff_complete_condition;
   bt::Condition *landed_condition;
   bt::Condition *in_air_condition;
+  bt::Condition *got_initial_ipp_plan_condition;
+  bt::Condition *get_initial_ipp_plan_commanded;
 
   // actions
   std::vector<bt::Action *> actions;
-  bt::Action *request_control_action;
-  bt::Action *arm_action;
+  bt::Action *reset_bt_action;
   bt::Action *disarm_action;
+  bt::Action *arm_action;
+  bt::Action *set_local_pos_ref_action;
+  bt::Action *request_control_action;
+  bt::Action *idle_action;
   bt::Action *takeoff_action;
   bt::Action *land_action;
   bt::Action *traj_control_action;
   bt::Action *coverage_planner_action;
   bt::Action *ipp_planner_action;
+  bt::Action *get_initial_ipp_plan_action;
 
   // services
   ros::ServiceClient takeoff_landing_client;
@@ -60,18 +70,21 @@ class BehaviorExecutive : public BaseNode {
   ros::ServiceClient vx_reset_integrator_client, vy_reset_integrator_client,
       vz_reset_integrator_client, yawrate_reset_integrator_client;
   ros::ServiceClient publish_control_client;
+  ros::ServiceClient set_local_pos_ref_client;
 
   // publishers
   ros::Publisher fixed_trajectory_pub;
   ros::Publisher in_air_pub;
   ros::Publisher generate_ipp_plan_request_pub;
+  ros::Publisher execute_ipp_plan_pub;
+  ros::Publisher wait_for_initial_ipp_plan_pub;
 
   // subscribers
   ros::Subscriber behavior_tree_command_sub;
   ros::Subscriber takeoff_state_sub;
   ros::Subscriber landing_state_sub;
   ros::Subscriber has_control_sub;
-  ros::Subscriber is_armed_sub;
+  ros::Subscriber got_initial_ipp_plan_sub;
 
   // callbacks
   void behavior_tree_command_callback(
@@ -79,7 +92,11 @@ class BehaviorExecutive : public BaseNode {
   void takeoff_state_callback(std_msgs::String msg);
   void landing_state_callback(std_msgs::String msg);
   void has_control_callback(std_msgs::Bool msg);
-  void is_armed_callback(std_msgs::Bool msg);
+  void got_initial_ipp_plan_callback(std_msgs::Bool msg);
+
+  void reset_integrators();
+  void enable_pose_controller_output();
+  void disable_pose_controller_output();
 
  public:
   BehaviorExecutive(std::string node_name);

--- a/firefly_control/src/behavior_executive.cpp
+++ b/firefly_control/src/behavior_executive.cpp
@@ -13,56 +13,96 @@ bool BehaviorExecutive::initialize() {
   ros::NodeHandle* pnh = get_private_node_handle();
 
   // init conditions
+  reset_bt_commanded_condition =
+      new bt::Condition("Reset Behavior Tree Commanded");
+  disarm_commanded_condition = new bt::Condition("Disarm Commanded");
+  arm_commanded_condition = new bt::Condition("Arm Commanded");
+  set_local_pos_ref_commanded_condition =
+      new bt::Condition("Set Local Position Reference Commanded");
+
+  local_pos_ref_set_condition =
+      new bt::Condition("Local Position Reference Set");
+
   request_control_commanded_condition =
       new bt::Condition("Request Control Commanded");
-  takeoff_commanded_condition = new bt::Condition("Takeoff Commanded");
-  land_commanded_condition = new bt::Condition("Land Commanded");
-  arm_commanded_condition = new bt::Condition("Arm Commanded");
-  disarm_commanded_condition = new bt::Condition("Disarm Commanded");
-  traj_control_commanded_condition =
-      new bt::Condition("Traj Control Commanded");
-  coverage_planner_commanded_condition =
-      new bt::Condition("Coverage Planner Commanded");
-  ipp_planner_commanded_condition = new bt::Condition("IPP Planner Commanded");
+  have_control_condition = new bt::Condition("Have Control");
+
+  autonomy_idle_condition = new bt::Condition("Autonomy Mode Is Idle");
+  autonomy_takeoff_condition = new bt::Condition("Autonomy Mode Is Takeoff");
+  autonomy_land_condition = new bt::Condition("Autonomy Mode Is Land");
+  autonomy_traj_control_condition =
+      new bt::Condition("Autonomy Mode Is Traj Control");
+  autonomy_coverage_planner_condition =
+      new bt::Condition("Autonomy Mode Is Coverage Planner");
+  autonomy_ipp_planner_condition =
+      new bt::Condition("Autonomy Mode Is IPP Planner");
 
   offboard_mode_condition = new bt::Condition("Offboard Mode");
-  armed_condition = new bt::Condition("Armed");
   takeoff_complete_condition = new bt::Condition("Takeoff Complete");
   landed_condition = new bt::Condition("Landed");
   in_air_condition = new bt::Condition("In Air");
+  got_initial_ipp_plan_condition = new bt::Condition("Got Initial IPP Plan");
+  get_initial_ipp_plan_commanded =
+      new bt::Condition("Get Initial IPP Plan Commanded");
 
-  conditions.push_back(request_control_commanded_condition);
-  conditions.push_back(takeoff_commanded_condition);
-  conditions.push_back(land_commanded_condition);
-  conditions.push_back(arm_commanded_condition);
+  conditions.push_back(reset_bt_commanded_condition);
   conditions.push_back(disarm_commanded_condition);
-  conditions.push_back(traj_control_commanded_condition);
-  conditions.push_back(coverage_planner_commanded_condition);
-  conditions.push_back(ipp_planner_commanded_condition);
+  conditions.push_back(arm_commanded_condition);
+  conditions.push_back(set_local_pos_ref_commanded_condition);
+  conditions.push_back(local_pos_ref_set_condition);
+  conditions.push_back(request_control_commanded_condition);
+  conditions.push_back(have_control_condition);
+  conditions.push_back(autonomy_idle_condition);
+  conditions.push_back(autonomy_takeoff_condition);
+  conditions.push_back(autonomy_land_condition);
+  conditions.push_back(autonomy_traj_control_condition);
+  conditions.push_back(autonomy_coverage_planner_condition);
+  conditions.push_back(autonomy_ipp_planner_condition);
   conditions.push_back(offboard_mode_condition);
-  conditions.push_back(armed_condition);
   conditions.push_back(takeoff_complete_condition);
   conditions.push_back(landed_condition);
   conditions.push_back(in_air_condition);
+  conditions.push_back(got_initial_ipp_plan_condition);
+  conditions.push_back(get_initial_ipp_plan_commanded);
+
+  autonomy_mode_conditions.push_back(autonomy_idle_condition);
+  autonomy_mode_conditions.push_back(autonomy_takeoff_condition);
+  autonomy_mode_conditions.push_back(autonomy_land_condition);
+  autonomy_mode_conditions.push_back(autonomy_traj_control_condition);
+  autonomy_mode_conditions.push_back(autonomy_coverage_planner_condition);
+  autonomy_mode_conditions.push_back(autonomy_ipp_planner_condition);
 
   // init actions
-  takeoff_action = new bt::Action("Takeoff");
-  land_action = new bt::Action("Land");
-  request_control_action = new bt::Action("Request Control");
-  arm_action = new bt::Action("Arm");
+  reset_bt_action = new bt::Action("Reset Behavior Tree");
   disarm_action = new bt::Action("Disarm");
-  traj_control_action = new bt::Action("Traj Control");
-  coverage_planner_action = new bt::Action("Coverage Planner");
-  ipp_planner_action = new bt::Action("IPP Planner");
+  arm_action = new bt::Action("Arm");
+  set_local_pos_ref_action = new bt::Action("Set Local Position Reference");
+  request_control_action = new bt::Action("Request Control");
 
+  idle_action = new bt::Action("Autonomy Idle");
+  takeoff_action = new bt::Action("Autonomy Takeoff");
+  land_action = new bt::Action("Autonomy Land");
+
+  traj_control_action = new bt::Action("Autonomy Traj Control");
+  coverage_planner_action = new bt::Action("Autonomy Coverage Planner");
+  ipp_planner_action = new bt::Action("Autonomy IPP Planner");
+
+  get_initial_ipp_plan_action = new bt::Action("Idle and Get Initial IPP Plan");
+
+  actions.push_back(reset_bt_action);
+  actions.push_back(disarm_action);
+  actions.push_back(arm_action);
+  actions.push_back(set_local_pos_ref_action);
+  actions.push_back(request_control_action);
+
+  actions.push_back(idle_action);
   actions.push_back(takeoff_action);
   actions.push_back(land_action);
-  actions.push_back(request_control_action);
-  actions.push_back(arm_action);
-  actions.push_back(disarm_action);
+
   actions.push_back(traj_control_action);
   actions.push_back(coverage_planner_action);
   actions.push_back(ipp_planner_action);
+  actions.push_back(get_initial_ipp_plan_action);
 
   // init services
   takeoff_landing_client =
@@ -91,12 +131,18 @@ bool BehaviorExecutive::initialize() {
       "velocity_controller/yawrate/reset_integrator");
   publish_control_client =
       nh->serviceClient<std_srvs::SetBool>("pose_controller/publish_control");
+  set_local_pos_ref_client =
+      nh->serviceClient<dji_sdk::SetLocalPosRef>("dji_sdk/set_local_pos_ref");
 
   // init publishers
   fixed_trajectory_pub = nh->advertise<core_trajectory_msgs::FixedTrajectory>(
       "fixed_trajectory", 10);
   in_air_pub = nh->advertise<std_msgs::Bool>("in_air", 1);
-  generate_ipp_plan_request_pub = nh->advertise<std_msgs::Empty>("generate_ipp_plan_request", 1);
+  generate_ipp_plan_request_pub =
+      nh->advertise<std_msgs::Empty>("generate_ipp_plan_request", 1);
+  execute_ipp_plan_pub = nh->advertise<std_msgs::Bool>("execute_ipp_plan", 1);
+  wait_for_initial_ipp_plan_pub =
+      nh->advertise<std_msgs::Empty>("wait_for_initial_ipp_plan", 1);
 
   // init subscribers
   behavior_tree_command_sub =
@@ -108,8 +154,9 @@ bool BehaviorExecutive::initialize() {
       "landing_state", 10, &BehaviorExecutive::landing_state_callback, this);
   has_control_sub = nh->subscribe(
       "has_control", 10, &BehaviorExecutive::has_control_callback, this);
-  is_armed_sub = nh->subscribe("is_armed", 10,
-                               &BehaviorExecutive::is_armed_callback, this);
+  got_initial_ipp_plan_sub =
+      nh->subscribe("got_initial_ipp_plan", 10,
+                    &BehaviorExecutive::got_initial_ipp_plan_callback, this);
 
   return true;
 }
@@ -163,9 +210,48 @@ static core_trajectory_msgs::FixedTrajectory GetLawnmowerTraj() {
 }
 
 bool BehaviorExecutive::execute() {
+  // Reset behavior tree action
+  if (reset_bt_action->is_active()) {
+    if (reset_bt_action->active_has_changed()) {
+      disable_pose_controller_output();
+
+      for (int i = 0; i < conditions.size(); i++) {
+        conditions[i]->set(false);
+      }
+
+      reset_bt_action->set_success();
+      reset_bt_commanded_condition->set(false);
+    }
+  }
+
+  // Set local position reference action
+  if (set_local_pos_ref_action->is_active()) {
+    if (set_local_pos_ref_action->active_has_changed()) {
+      disable_pose_controller_output();
+
+      if (!local_pos_ref_set_condition->get()) {
+        // Only reset these conditions if this is the first time setting the local pos ref
+        takeoff_complete_condition->set(false);
+        landed_condition->set(false);
+        request_control_commanded_condition->set(false);
+        get_initial_ipp_plan_commanded->set(false);
+        have_control_condition->set(false);
+      }
+
+      dji_sdk::SetLocalPosRef set_local_pos_ref_srv;
+      set_local_pos_ref_client.call(set_local_pos_ref_srv);
+
+      set_local_pos_ref_action->set_success();
+      set_local_pos_ref_commanded_condition->set(false);
+      local_pos_ref_set_condition->set(true);
+    }
+  }
+
   // request control action
   if (request_control_action->is_active()) {
     if (request_control_action->active_has_changed()) {
+      disable_pose_controller_output();
+
       core_drone_interface::DroneCommand drone_command_srv;
       drone_command_srv.request.command =
           core_drone_interface::DroneCommand::Request::REQUEST_CONTROL;
@@ -174,35 +260,23 @@ bool BehaviorExecutive::execute() {
       if (drone_command_srv.response.success) {
         ROS_INFO("SUCCESS REQUEST CONTROL");
         request_control_action->set_success();
+        have_control_condition->set(true);
       } else {
         ROS_INFO("FAILED REQUEST CONTROL");
         request_control_action->set_failure();
       }
+      request_control_commanded_condition->set(false);
     }
   }
 
   // arm action
   if (arm_action->is_active()) {
     if (arm_action->active_has_changed()) {
-      // reset integrators before arming
-      std_srvs::Empty reset_srv;
-      x_reset_integrator_client.call(reset_srv);
-      y_reset_integrator_client.call(reset_srv);
-      z_reset_integrator_client.call(reset_srv);
-      yaw_reset_integrator_client.call(reset_srv);
-      vx_reset_integrator_client.call(reset_srv);
-      vy_reset_integrator_client.call(reset_srv);
-      vz_reset_integrator_client.call(reset_srv);
-      yawrate_reset_integrator_client.call(reset_srv);
+      disable_pose_controller_output();
 
       // set takeoff and land conditions to false before arming
       takeoff_complete_condition->set(false);
       landed_condition->set(false);
-
-      // Turn off pose controller output before arming
-      std_srvs::SetBool publish_control_srv;
-      publish_control_srv.request.data = false;
-      publish_control_client.call(publish_control_srv);
 
       // arm
       core_drone_interface::DroneCommand drone_command_srv;
@@ -217,17 +291,15 @@ bool BehaviorExecutive::execute() {
         ROS_INFO("ARMED FAILURE");
         arm_action->set_failure();
       }
-
-      core_trajectory_controller::TrajectoryMode srv;
-      srv.request.mode =
-          core_trajectory_controller::TrajectoryMode::Request::ROBOT_POSE;
-      trajectory_mode_client.call(srv);
+      arm_commanded_condition->set(false);
     }
   }
 
   // disarm action
   if (disarm_action->is_active()) {
     if (disarm_action->active_has_changed()) {
+      disable_pose_controller_output();
+
       in_air_condition->set(false);
       core_drone_interface::DroneCommand drone_command_srv;
       drone_command_srv.request.command =
@@ -237,32 +309,17 @@ bool BehaviorExecutive::execute() {
       if (drone_command_srv.response.success) {
         ROS_INFO("DISARMED SUCCESS");
         disarm_action->set_success();
-
-        // reset integrators after disarming
-        std_srvs::Empty reset_srv;
-        x_reset_integrator_client.call(reset_srv);
-        y_reset_integrator_client.call(reset_srv);
-        z_reset_integrator_client.call(reset_srv);
-        yaw_reset_integrator_client.call(reset_srv);
-        vx_reset_integrator_client.call(reset_srv);
-        vy_reset_integrator_client.call(reset_srv);
-        vz_reset_integrator_client.call(reset_srv);
-        yawrate_reset_integrator_client.call(reset_srv);
-
-        // Turn off pose controller output after disarming
-        std_srvs::SetBool publish_control_srv;
-        publish_control_srv.request.data = false;
-        publish_control_client.call(publish_control_srv);
-
-        // set the tracking point to be at the robot's position
-        core_trajectory_controller::TrajectoryMode srv;
-        srv.request.mode =
-            core_trajectory_controller::TrajectoryMode::Request::ROBOT_POSE;
-        trajectory_mode_client.call(srv);
       } else {
         ROS_INFO("DISARMED FAILURE");
         disarm_action->set_failure();
       }
+      disarm_commanded_condition->set(false);
+    }
+  }
+
+  if (idle_action->is_active()) {
+    if (idle_action->active_has_changed()) {
+      disable_pose_controller_output();
     }
   }
 
@@ -272,15 +329,13 @@ bool BehaviorExecutive::execute() {
     in_air_condition->set(true);
 
     if (takeoff_action->active_has_changed()) {
-      // Turn on pose controller output
-      std_srvs::SetBool publish_control_srv;
-      publish_control_srv.request.data = true;
-      publish_control_client.call(publish_control_srv);
-
       core_takeoff_landing_planner::TakeoffLandingCommand takeoff_srv;
       takeoff_srv.request.command =
           core_takeoff_landing_planner::TakeoffLandingCommand::Request::TAKEOFF;
       takeoff_landing_client.call(takeoff_srv);
+
+      // Turn on pose controller output
+      enable_pose_controller_output();
     }
 
     if (takeoff_state == "COMPLETE") {
@@ -294,15 +349,12 @@ bool BehaviorExecutive::execute() {
     land_action->set_running();
 
     if (land_action->active_has_changed()) {
-      // Turn on pose controller output
-      std_srvs::SetBool publish_control_srv;
-      publish_control_srv.request.data = true;
-      publish_control_client.call(publish_control_srv);
-
       core_takeoff_landing_planner::TakeoffLandingCommand land_srv;
       land_srv.request.command =
           core_takeoff_landing_planner::TakeoffLandingCommand::Request::LAND;
       takeoff_landing_client.call(land_srv);
+      // Turn on pose controller output
+      enable_pose_controller_output();
     }
 
     if (landing_state == "COMPLETE") {
@@ -316,17 +368,14 @@ bool BehaviorExecutive::execute() {
     traj_control_action->set_running();
 
     if (traj_control_action->active_has_changed()) {
-      // Turn on pose controller output
-      std_srvs::SetBool publish_control_srv;
-      publish_control_srv.request.data = true;
-      publish_control_client.call(publish_control_srv);
-
       core_trajectory_controller::TrajectoryMode srv;
       srv.request.mode =
           core_trajectory_controller::TrajectoryMode::Request::TRACK;
       trajectory_mode_client.call(srv);
       const auto fixed_trajectory = GetSquareFixedTraj();
       fixed_trajectory_pub.publish(fixed_trajectory);
+      // Turn on pose controller output
+      enable_pose_controller_output();
     }
   }
 
@@ -335,17 +384,14 @@ bool BehaviorExecutive::execute() {
     coverage_planner_action->set_running();
 
     if (coverage_planner_action->active_has_changed()) {
-      // Turn on pose controller output
-      std_srvs::SetBool publish_control_srv;
-      publish_control_srv.request.data = true;
-      publish_control_client.call(publish_control_srv);
-
       core_trajectory_controller::TrajectoryMode srv;
       srv.request.mode =
           core_trajectory_controller::TrajectoryMode::Request::TRACK;
       trajectory_mode_client.call(srv);
       const auto fixed_trajectory = GetLawnmowerTraj();
       fixed_trajectory_pub.publish(fixed_trajectory);
+      // Turn on pose controller output
+      enable_pose_controller_output();
     }
   }
 
@@ -354,18 +400,39 @@ bool BehaviorExecutive::execute() {
     ipp_planner_action->set_running();
 
     if (ipp_planner_action->active_has_changed()) {
-      // Turn on pose controller output
-      std_srvs::SetBool publish_control_srv;
-      publish_control_srv.request.data = true;
-      publish_control_client.call(publish_control_srv);
-
       core_trajectory_controller::TrajectoryMode srv;
       srv.request.mode =
           core_trajectory_controller::TrajectoryMode::Request::TRACK;
       trajectory_mode_client.call(srv);
 
+      std_msgs::Bool true_msg;
+      true_msg.data = true;
+      execute_ipp_plan_pub.publish(true_msg);
+      
+      // Turn on pose controller output
+      enable_pose_controller_output();
+    }
+  } else {
+    // Transitioned from active to inactive
+    if (ipp_planner_action->active_has_changed()) {
+      std_msgs::Bool false_msg;
+      false_msg.data = false;
+      execute_ipp_plan_pub.publish(false_msg);
+    }
+  }
+
+  // Generate an initial ipp plan
+  if (get_initial_ipp_plan_action->is_active()) {
+    if (get_initial_ipp_plan_action->active_has_changed()) {
       std_msgs::Empty empty_msg;
       generate_ipp_plan_request_pub.publish(empty_msg);
+      wait_for_initial_ipp_plan_pub.publish(empty_msg);
+
+      for (int i = 0; i < autonomy_mode_conditions.size(); i++) {
+        autonomy_mode_conditions[i]->set(false);
+      }
+      autonomy_idle_condition->set(true);
+      get_initial_ipp_plan_commanded->set(false);
     }
   }
 
@@ -382,15 +449,6 @@ bool BehaviorExecutive::execute() {
 
 void BehaviorExecutive::behavior_tree_command_callback(
     behavior_tree_msgs::BehaviorTreeCommands msg) {
-  request_control_commanded_condition->set(false);
-  arm_commanded_condition->set(false);
-  disarm_commanded_condition->set(false);
-  takeoff_commanded_condition->set(false);
-  land_commanded_condition->set(false);
-  traj_control_commanded_condition->set(false);
-  coverage_planner_commanded_condition->set(false);
-  ipp_planner_commanded_condition->set(false);
-
   for (int i = 0; i < msg.commands.size(); i++) {
     std::string condition_name = msg.commands[i].condition_name;
     int status = msg.commands[i].status;
@@ -398,10 +456,18 @@ void BehaviorExecutive::behavior_tree_command_callback(
     for (int j = 0; j < conditions.size(); j++) {
       bt::Condition* condition = conditions[j];
       if (condition_name == condition->get_label()) {
-        if (status == behavior_tree_msgs::Status::SUCCESS)
+        if (status == behavior_tree_msgs::Status::SUCCESS) {
+          if (std::find(autonomy_mode_conditions.begin(),
+                        autonomy_mode_conditions.end(),
+                        condition) != autonomy_mode_conditions.end()) {
+            for (int i = 0; i < autonomy_mode_conditions.size(); i++) {
+              autonomy_mode_conditions[i]->set(false);
+            }
+          }
           condition->set(true);
-        else if (status == behavior_tree_msgs::Status::FAILURE)
+        } else if (status == behavior_tree_msgs::Status::FAILURE) {
           condition->set(false);
+        }
       }
     }
   }
@@ -419,8 +485,45 @@ void BehaviorExecutive::has_control_callback(std_msgs::Bool msg) {
   offboard_mode_condition->set(msg.data);
 }
 
-void BehaviorExecutive::is_armed_callback(std_msgs::Bool msg) {
-  armed_condition->set(msg.data);
+void BehaviorExecutive::got_initial_ipp_plan_callback(std_msgs::Bool msg) {
+  got_initial_ipp_plan_condition->set(msg.data);
+}
+
+void BehaviorExecutive::reset_integrators() {
+  std_srvs::Empty reset_srv;
+  x_reset_integrator_client.call(reset_srv);
+  y_reset_integrator_client.call(reset_srv);
+  z_reset_integrator_client.call(reset_srv);
+  yaw_reset_integrator_client.call(reset_srv);
+  vx_reset_integrator_client.call(reset_srv);
+  vy_reset_integrator_client.call(reset_srv);
+  vz_reset_integrator_client.call(reset_srv);
+  yawrate_reset_integrator_client.call(reset_srv);
+}
+
+void BehaviorExecutive::enable_pose_controller_output() {
+  reset_integrators();
+
+  std_srvs::SetBool publish_control_srv;
+  publish_control_srv.request.data = true;
+  publish_control_client.call(publish_control_srv);
+}
+
+void BehaviorExecutive::disable_pose_controller_output() {
+  reset_integrators();
+
+  std_srvs::SetBool publish_control_srv;
+  publish_control_srv.request.data = false;
+  publish_control_client.call(publish_control_srv);
+
+  core_trajectory_controller::TrajectoryMode srv;
+  srv.request.mode =
+      core_trajectory_controller::TrajectoryMode::Request::ROBOT_POSE;
+  trajectory_mode_client.call(srv);
+
+  for (int i = 0; i < autonomy_mode_conditions.size(); i++) {
+    autonomy_mode_conditions[i]->set(false);
+  }
 }
 
 BehaviorExecutive::~BehaviorExecutive() {}

--- a/firefly_control/src/fixed_trajectory_generator.py
+++ b/firefly_control/src/fixed_trajectory_generator.py
@@ -396,12 +396,20 @@ def get_horizontal_lawnmower_waypoints(attributes):
     traj = TrajectoryXYZVYaw()
     traj.header.frame_id = frame_id
 
+    wp1 = WaypointXYZVYaw()
+    wp1.position.x = 0
+    wp1.position.y = 0
+    wp1.position.z = height
+    wp1.yaw = np.deg2rad(83.63349151611328+90.0)
+    wp1.velocity = 3.0
+    traj.waypoints.append(wp1)
+
     for (x,y) in path:
         wp1 = WaypointXYZVYaw()
         wp1.position.x = x
         wp1.position.y = y
         wp1.position.z = height
-        wp1.yaw = 90
+        wp1.yaw = np.deg2rad(83.63349151611328+90.0)
         wp1.velocity = velocity
         traj.waypoints.append(wp1)
 
@@ -436,7 +444,7 @@ def get_coverage_waypoints(attributes):
         wp1.position.x = x
         wp1.position.y = y
         wp1.position.z = height
-        wp1.yaw = 90
+        wp1.yaw = np.pi/2
         wp1.velocity = velocity
         traj.waypoints.append(wp1)
 
@@ -464,8 +472,8 @@ def fixed_trajectory_callback(msg):
     elif msg.type == 'Rectangle':
         trajectory_msg = get_rectangle_waypoints(attributes)
     elif msg.type == 'Horizontal_Lawnmower':
-        # trajectory_msg = get_horizontal_lawnmower_waypoints(attributes)
-        trajectory_msg = get_coverage_waypoints(attributes)
+        trajectory_msg = get_horizontal_lawnmower_waypoints(attributes)
+        # trajectory_msg = get_coverage_waypoints(attributes)
 
     if trajectory_msg != None:
         trajectory_track_pub.publish(trajectory_msg)

--- a/firefly_telemetry/src/gcs_telemetry.py
+++ b/firefly_telemetry/src/gcs_telemetry.py
@@ -476,7 +476,7 @@ class GCSTelemetry:
         self.idle_send_flag = True
 
     def reset_behavior_tree_callback(self, empty_msg):
-        self.reset_behavior_tree_callback = True
+        self.reset_behavior_tree_send_flag = True
 
 
 if __name__ == "__main__":

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -27,11 +27,10 @@ import struct
 import time
 import serial
 import datetime
-from geometry_msgs.msg import Pose
+from geometry_msgs.msg import Pose, Polygon, Point32
 from std_msgs.msg import Bool, Float32
 from sensor_msgs.msg import BatteryState, NavSatFix
 from behavior_tree_msgs.msg import BehaviorTreeCommand, BehaviorTreeCommands, Status
-from dji_sdk.srv import SetLocalPosRef
 from planner_map_interfaces.msg import Plan
 
 os.environ['MAVLINK20'] = '1'
@@ -39,7 +38,10 @@ os.environ['MAVLINK20'] = '1'
 
 class OnboardTelemetry:
     def __init__(self):
-        self.connection = mavutil.mavlink_connection('/dev/mavlink', baud=57600, dialect='firefly')
+        self.connection = mavutil.mavlink_connection(
+            "/dev/mavlink", baud=115200, dialect="firefly"
+        )
+
 
         self.tfBuffer = tf2_ros.Buffer()
         self.listener = tf2_ros.TransformListener(self.tfBuffer)
@@ -67,8 +69,6 @@ class OnboardTelemetry:
         self.ipp_transmit_buf = []
         self.ipp_nt = 0
         self.ipp_na = 0
-        self.send_ipp_plan_flag = False
-        self.ipp_transmit_complete_flag = False
 
         rospy.Subscriber("new_fire_bins", Int32MultiArray, self.new_fire_bins_callback)
         rospy.Subscriber("new_no_fire_bins", Int32MultiArray, self.new_no_fire_bins_callback)
@@ -77,18 +77,16 @@ class OnboardTelemetry:
         rospy.Subscriber("dji_sdk/gps_position", NavSatFix , self.get_altitude_callback)
         rospy.Subscriber("dji_sdk/battery_state", BatteryState, self.battery_health_callback)
         rospy.Subscriber("onboard_temperature", Float32, self.onboard_temperature_callback)
-        rospy.Subscriber("/global_path", Plan, self.ipp_publish_callback)
+        rospy.Subscriber("initial_ipp_plan_to_transmit", Plan, self.ipp_publish_callback)
 
-        self.set_local_pos_ref_pub = rospy.Publisher("set_local_pos_ref", Empty, queue_size=100)
         self.clear_map_pub = rospy.Publisher("clear_map", Empty, queue_size=100)
         self.behavior_tree_commands_pub = rospy.Publisher("behavior_tree_commands", BehaviorTreeCommands, queue_size=100)
         self.kill_switch = rospy.Publisher("kill_switch", Empty, queue_size=10)
-        self.execute_ipp_pub = rospy.Publisher("execute_ipp_plan", Empty, queue_size=1)
 
         rospy.Timer(rospy.Duration(0.5), self.pose_send_callback)
         self.extract_frame_pub = rospy.Publisher("extract_frame", Empty, queue_size=1)
 
-        self.bytes_per_sec_send_rate = 1000.0
+        self.bytes_per_sec_send_rate = 2000.0
         self.mavlink_packet_overhead_bytes = 12
 
         self.last_heartbeat_time = None
@@ -107,7 +105,9 @@ class OnboardTelemetry:
 
         self.recording_ros_bag = False
         try:
-            self.connection = mavutil.mavlink_connection('/dev/mavlink', baud=57600, dialect='firefly')
+            self.connection = mavutil.mavlink_connection(
+                "/dev/mavlink", baud=115200, dialect="firefly"
+            )
             self.connectedToOnboardRadio = True
             rospy.loginfo("Opened connection to onboard radio")
         except serial.serialutil.SerialException:
@@ -141,10 +141,10 @@ class OnboardTelemetry:
 
     def get_altitude_callback(self, data):
         self.altitude = data.altitude
-    
+
     def battery_health_callback(self, data):
         self.battery_charge = data.percentage
-    
+
     def onboard_temperature_callback(self, data):
         self.onboard_temperature = data.data
 
@@ -152,26 +152,22 @@ class OnboardTelemetry:
         self.pose_send_flag = True
 
     def ipp_publish_callback(self, ipp_plan):
-        '''
-            init plan array to be published
-            discard new plan if previous one is yet to be transmitted
-        '''
-        if self.send_ipp_plan_flag:
-            return
-        self.send_ipp_plan_flag = True
-        self.ipp_plan = []
+        self.ipp_plan.append({"type": "start"})
         for idx, wp in enumerate(ipp_plan.plan):
             plan_msg = {
                 "x": wp.position.position.x,
                 "y": wp.position.position.y,
                 "z": wp.position.position.z,
-                "q": [wp.position.orientation.x,
-                     wp.position.orientation.y,
-                     wp.position.orientation.z,
-                     wp.position.orientation.w],
-                "seq_num": idx
+                "q": [
+                    wp.position.orientation.x,
+                    wp.position.orientation.y,
+                    wp.position.orientation.z,
+                    wp.position.orientation.w,
+                ],
+                "type": "waypoint",
             }
             self.ipp_plan.append(plan_msg)
+        self.ipp_plan.append({"type": "end"})
 
     def send_map_update(self):
         if (len(self.map_transmitted_buf) != 0) and (
@@ -194,8 +190,8 @@ class OnboardTelemetry:
                 y = payload.position.y
                 z = payload.position.z
                 q = [payload.orientation.x,
-                     payload.orientation.y,
-                     payload.orientation.z,
+                    payload.orientation.y,
+                    payload.orientation.z,
                      payload.orientation.w]
                 self.map_transmitted_buf.append((time.time(), 2, seq_num, -1, payload))
                 rospy.logwarn("Warning: Resending packet with sequence id: %d" % seq_num)
@@ -250,8 +246,8 @@ class OnboardTelemetry:
                 y = updates_to_send.position.y
                 z = updates_to_send.position.z
                 q = [updates_to_send.orientation.x,
-                     updates_to_send.orientation.y,
-                     updates_to_send.orientation.z,
+                    updates_to_send.orientation.y,
+                    updates_to_send.orientation.z,
                      updates_to_send.orientation.w]
                 seq_num = self.nt
                 self.map_transmitted_buf.append((time.time(), 2, seq_num, -1, updates_to_send))
@@ -269,8 +265,8 @@ class OnboardTelemetry:
             y = transform.transform.translation.y
             z = transform.transform.translation.z
             q = [transform.transform.rotation.x,
-                 transform.transform.rotation.y,
-                 transform.transform.rotation.z,
+                transform.transform.rotation.y,
+                transform.transform.rotation.z,
                  transform.transform.rotation.w]
             self.connection.mav.firefly_pose_send(x, y, z, q)
             rospy.sleep((self.mavlink_packet_overhead_bytes + 28) / self.bytes_per_sec_send_rate)
@@ -286,13 +282,27 @@ class OnboardTelemetry:
             ipp_packet = self.ipp_transmit_buf.pop(0)
             ipp_packet["timestamp"] = time.time()
             self.ipp_transmit_buf.append(ipp_packet)
-            rospy.logwarn("Warning: Resending packet with sequence id: %d" % ipp_packet['seq_num'])
-            self.connection.mav.firefly_ipp_plan_preview_send(ipp_packet['seq_num'],
-                                                                ipp_packet['x'],
-                                                                ipp_packet['y'],
-                                                                ipp_packet['z'],
-                                                                ipp_packet['q'])
-            rospy.sleep((self.mavlink_packet_overhead_bytes + 29) / self.bytes_per_sec_send_rate)
+            rospy.logwarn(
+                "Warning: Resending packet with sequence id: %d" % ipp_packet["seq_num"]
+            )
+            if ipp_packet["type"] == "waypoint":
+                self.connection.mav.firefly_ipp_plan_preview_send(
+                    ipp_packet["seq_num"],
+                    ipp_packet["x"],
+                    ipp_packet["y"],
+                    ipp_packet["z"],
+                    ipp_packet["q"],
+                )
+                rospy.sleep((self.mavlink_packet_overhead_bytes + 29) / self.bytes_per_sec_send_rate)
+
+            elif ipp_packet["type"] == "start":
+                self.connection.mav.firefly_ipp_transmit_start_send(ipp_packet["seq_num"])
+                rospy.sleep((self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate)
+
+            elif ipp_packet["type"] == "end":
+                self.connection.mav.firefly_ipp_transmit_complete_send(ipp_packet["seq_num"])
+                rospy.sleep((self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate)
+
             return
         elif (self.ipp_nt - self.ipp_na) % 128 >= self.wt:
             # Waiting for acks
@@ -301,19 +311,27 @@ class OnboardTelemetry:
         elif len(self.ipp_plan) != 0:
             next_wp = self.ipp_plan.pop(0)
             next_wp["timestamp"] = time.time()
+            next_wp["seq_num"] = self.ipp_nt
             self.ipp_transmit_buf.append(next_wp)
             self.ipp_nt = (self.ipp_nt + 1) % 128
-            self.connection.mav.firefly_ipp_plan_preview_send(next_wp['seq_num'],
-                                                                next_wp['x'],
-                                                                next_wp['y'],
-                                                                next_wp['z'],
-                                                                next_wp['q'])
-            rospy.sleep((self.mavlink_packet_overhead_bytes + 29) / self.bytes_per_sec_send_rate)
-        else:
-            self.send_ipp_plan_flag = False
-            self.ipp_nt = 0
-            self.ipp_na = 0
-            self.ipp_transmit_complete_flag = True
+
+            if next_wp["type"] == "waypoint":
+                self.connection.mav.firefly_ipp_plan_preview_send(
+                    next_wp["seq_num"],
+                    next_wp["x"],
+                    next_wp["y"],
+                    next_wp["z"],
+                    next_wp["q"],
+                )
+                rospy.sleep((self.mavlink_packet_overhead_bytes + 29) / self.bytes_per_sec_send_rate)
+
+            elif next_wp["type"] == "start":
+                self.connection.mav.firefly_ipp_transmit_start_send(next_wp["seq_num"])
+                rospy.sleep((self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate)
+
+            elif next_wp["type"] == "end":
+                self.connection.mav.firefly_ipp_transmit_complete_send(next_wp["seq_num"])
+                rospy.sleep((self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate)
 
 
     def run(self):
@@ -332,6 +350,7 @@ class OnboardTelemetry:
                 if self.connectedToGCS:
                     self.send_map_update()
                     self.send_pose_update()
+                    self.send_ipp_plan()
 
                 if self.heartbeat_send_flag:
                     if self.camera_health:
@@ -341,9 +360,9 @@ class OnboardTelemetry:
                     rospy.logdebug("Sending Heartbeat")
                     self.heartbeat_send_flag = False
                     rospy.sleep((self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate)
-              
+
                 #send altitude
-                if self.altitude_status_send_flag: 
+                if self.altitude_status_send_flag:
                     self.connection.mav.firefly_altitude_send(float(self.altitude))
                     self.altitude_status_send_flag = False
                     rospy.sleep((self.mavlink_packet_overhead_bytes + 4) / self.bytes_per_sec_send_rate)
@@ -357,21 +376,15 @@ class OnboardTelemetry:
                     self.connection.mav.firefly_onboard_temp_send(self.onboard_temperature)
                     self.temperature_status_send_flag = False
                     rospy.sleep((self.mavlink_packet_overhead_bytes + 4) / self.bytes_per_sec_send_rate)
-                # send ipp preview
-                if self.send_ipp_plan_flag:
-                    self.send_ipp_plan()
-                # send acknowledgement of complete ipp preview transmission
-                if self.ipp_transmit_complete_flag:
-                    self.ipp_transmit_complete_flag = False
-                    self.connection.mav.firefly_ipp_transmit_complete_send(1)
-                    rospy.sleep((self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate)
 
             except serial.serialutil.SerialException as e:
                 self.connectedToOnboardRadio = False
                 rospy.logerr(e)
         elif time.time() - self.last_serial_attempt_time >= self.serial_reconnect_wait_time:
             try:
-                self.connection = mavutil.mavlink_connection('/dev/mavlink', baud=57600, dialect='firefly')
+                self.connection = mavutil.mavlink_connection(
+                    "/dev/mavlink", baud=115200, dialect="firefly"
+                )
                 rospy.loginfo("Opened connection to Onboard radio")
                 self.connectedToOnboardRadio = True
             except serial.serialutil.SerialException as e:
@@ -389,16 +402,6 @@ class OnboardTelemetry:
 
         if msg['mavpackettype'] == 'FIREFLY_CLEAR_MAP':
             self.clear_map_pub.publish(Empty())
-        elif msg['mavpackettype'] == 'FIREFLY_SET_LOCAL_POS_REF':
-            self.clear_map_pub.publish(Empty())
-            rospy.wait_for_service('dji_sdk/set_local_pos_ref', timeout=0.1)
-            try:
-                set_local_pos_ref = rospy.ServiceProxy('dji_sdk/set_local_pos_ref', SetLocalPosRef)
-                response = set_local_pos_ref()
-                # self.connection.mav.firefly_local_pos_ref_send(response.latitude, response.longitude, response.altitude)
-                self.connection.mav.firefly_local_pos_ref_send(0, 0, 0)
-            except rospy.ServiceException as e:
-                rospy.logerr("Service call failed: %s" % e)            
         elif msg['mavpackettype'] == 'FIREFLY_KILL':
             self.kill_switch.publish(Empty())
         elif msg['mavpackettype'] == 'FIREFLY_GET_FRAME':
@@ -431,9 +434,22 @@ class OnboardTelemetry:
             if self.na == msg['seq_num']:
                 self.na = self.nt
                 for i in range(len(self.map_transmitted_buf) - 1, -1, -1):
-                    if self.map_transmitted_buf[i][2] < self.na:
+                    if  (self.na - self.map_transmitted_buf[i][2]) % 128 <= self.wt:
                         self.na = self.map_transmitted_buf[i][2]
-        elif msg['mavpackettype'] == 'FIREFLY_REQUEST_CONTROL':
+        elif msg["mavpackettype"] == "FIREFLY_RESET_BEHAVIOR_TREE":
+            command = BehaviorTreeCommand()
+            command.condition_name = "Reset Behavior Tree Commanded"
+            command.status = Status.SUCCESS
+            behavior_tree_commands.commands.append(command)
+        elif msg["mavpackettype"] == "FIREFLY_SET_LOCAL_POS_REF":
+            self.clear_map_pub.publish(Empty())
+            command = BehaviorTreeCommand()
+            command.condition_name = "Set Local Position Reference Commanded"
+            command.status = Status.SUCCESS
+            behavior_tree_commands.commands.append(command)
+            # self.connection.mav.firefly_local_pos_ref_send(response.latitude, response.longitude, response.altitude)
+            self.connection.mav.firefly_local_pos_ref_send(0, 0, 0)
+        elif msg["mavpackettype"] == "FIREFLY_REQUEST_CONTROL":
             command = BehaviorTreeCommand()
             command.condition_name = "Request Control Commanded"
             command.status = Status.SUCCESS
@@ -448,42 +464,49 @@ class OnboardTelemetry:
             command.condition_name = "Disarm Commanded"
             command.status = Status.SUCCESS
             behavior_tree_commands.commands.append(command)
-        elif msg['mavpackettype'] == 'FIREFLY_TAKEOFF':
+        elif msg["mavpackettype"] == "FIREFLY_IDLE":
             command = BehaviorTreeCommand()
-            command.condition_name = "Takeoff Commanded"
+            command.condition_name = "Autonomy Mode Is Idle"
             command.status = Status.SUCCESS
             behavior_tree_commands.commands.append(command)
-        elif msg['mavpackettype'] == 'FIREFLY_LAND':
+        elif msg["mavpackettype"] == "FIREFLY_TAKEOFF":
             command = BehaviorTreeCommand()
-            command.condition_name = "Land Commanded"
+            command.condition_name = "Autonomy Mode Is Takeoff"
             command.status = Status.SUCCESS
             behavior_tree_commands.commands.append(command)
-        elif msg['mavpackettype'] == 'FIREFLY_TRAJ_CONTROL':
+        elif msg["mavpackettype"] == "FIREFLY_LAND":
             command = BehaviorTreeCommand()
-            command.condition_name = "Traj Control Commanded"
+            command.condition_name = "Autonomy Mode Is Land)"
             command.status = Status.SUCCESS
             behavior_tree_commands.commands.append(command)
-        elif msg['mavpackettype'] == 'FIREFLY_COVERAGE_PLANNER':
+        elif msg["mavpackettype"] == "FIREFLY_TRAJ_CONTROL":
             command = BehaviorTreeCommand()
-            command.condition_name = "Coverage Planner Commanded"
+            command.condition_name = "Autonomy Mode Is Traj Control"
             command.status = Status.SUCCESS
             behavior_tree_commands.commands.append(command)
-        elif msg['mavpackettype'] == 'FIREFLY_IPP_PLANNER':
-            if not self.send_ipp_plan_flag:
-                command = BehaviorTreeCommand()
-                command.condition_name = "IPP Planner Commanded"
-                command.status = Status.SUCCESS
-                behavior_tree_commands.commands.append(command)
-        elif msg['mavpackettype'] == 'FIREFLY_EXECUTE_IPP_PLAN':
-            self.execute_ipp_pub.publish(Empty())
-        elif msg['mavpackettype'] == 'FIREFLY_IPP_PLAN_PREVIEW_ACK':
+        elif msg["mavpackettype"] == "FIREFLY_COVERAGE_PLANNER":
+            command = BehaviorTreeCommand()
+            command.condition_name = "Autonomy Mode Is Coverage Planner"
+            command.status = Status.SUCCESS
+            behavior_tree_commands.commands.append(command)
+        elif msg["mavpackettype"] == "FIREFLY_IPP_PLANNER":
+            command = BehaviorTreeCommand()
+            command.condition_name = "Get Initial IPP Plan Commanded"
+            command.status = Status.SUCCESS
+            behavior_tree_commands.commands.append(command)
+        elif msg["mavpackettype"] == "FIREFLY_EXECUTE_IPP_PLAN":
+            command = BehaviorTreeCommand()
+            command.condition_name = "Autonomy Mode Is IPP Planner"
+            command.status = Status.SUCCESS
+            behavior_tree_commands.commands.append(command)
+        elif msg["mavpackettype"] == "FIREFLY_IPP_PLAN_PREVIEW_ACK":
             for i in range(len(self.ipp_transmit_buf) - 1, -1, -1):
                 if self.ipp_transmit_buf[i]["seq_num"] == msg['seq_num']:
                     self.ipp_transmit_buf.pop(i)
             if self.ipp_na == msg['seq_num']:
                 self.ipp_na = self.ipp_nt
                 for i in range(len(self.ipp_transmit_buf) - 1, -1, -1):
-                    if self.ipp_transmit_buf[i]["seq_num"] < self.ipp_na:
+                    if (self.ipp_na - self.ipp_transmit_buf[i]["seq_num"]) % 128 <= self.wt:
                         self.ipp_na = self.ipp_transmit_buf[i]["seq_num"]
 
         if len(behavior_tree_commands.commands) > 0:
@@ -494,7 +517,7 @@ class OnboardTelemetry:
 
     def altitude_send_callback(self, event):
         self.altitude_status_send_flag = True
-    
+
     def battery_status_send_callback(self, event):
         self.battery_status_send_flag = True
 

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -476,7 +476,7 @@ class OnboardTelemetry:
             behavior_tree_commands.commands.append(command)
         elif msg["mavpackettype"] == "FIREFLY_LAND":
             command = BehaviorTreeCommand()
-            command.condition_name = "Autonomy Mode Is Land)"
+            command.condition_name = "Autonomy Mode Is Land"
             command.status = Status.SUCCESS
             behavior_tree_commands.commands.append(command)
         elif msg["mavpackettype"] == "FIREFLY_TRAJ_CONTROL":

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -27,7 +27,7 @@ import struct
 import time
 import serial
 import datetime
-from geometry_msgs.msg import Pose, Polygon, Point32
+from geometry_msgs.msg import Pose
 from std_msgs.msg import Bool, Float32
 from sensor_msgs.msg import BatteryState, NavSatFix
 from behavior_tree_msgs.msg import BehaviorTreeCommand, BehaviorTreeCommands, Status

--- a/pymavlink/message_definitions/v1.0/firefly.xml
+++ b/pymavlink/message_definitions/v1.0/firefly.xml
@@ -5488,7 +5488,7 @@
       <description>Command perception node to extract frame and pass it on for segmentation</description>
       <field type="uint8_t" name="get_frame">Boolean to decide whether to extract frame (1) or not (0)</field>
     </message>
-    <message id="13002" name="FIREFLY_CLEAR_MAP"> 
+    <message id="13002" name="FIREFLY_CLEAR_MAP">
       <description>Command to clear the current occupancy grid map</description>
       <field type="uint8_t" name="empty">Empty byte since mavlink requires a non-zero payload</field>
     </message>
@@ -5532,7 +5532,7 @@
       <field type="float" name="x" units="m">X Position</field>
       <field type="float" name="y" units="m">Y Position</field>
       <field type="float" name="z" units="m">Z Position</field>
-      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field> 
+      <field type="float[4]" name="q">Quaternion components, w, x, y, z (1 0 0 0 is the null-rotation)</field>
     </message>
     <message id="13011" name="FIREFLY_BATTERY_STATUS">
       <description>Message type to transmit battery status over telemetry</description>
@@ -5546,11 +5546,11 @@
       <description>Message type to transmit the altitude over telemetry</description>
       <field type="float" name="alt">Integer defining altitude</field>
     </message>
-      <message id="13014" name="FIREFLY_EXEC_AUTO">
+    <message id="13014" name="FIREFLY_EXEC_AUTO">
       <description>Command to begin autonomous flight</description>
       <field type="uint8_t" name="empty">Empty byte since mavlink requires a non-zero payload</field>
-      </message>
-      <message id="13015" name="FIREFLY_KILL">
+    </message>
+    <message id="13015" name="FIREFLY_KILL">
       <description>Command to execute Kill Switch</description>
       <field type="uint8_t" name="empty">Empty byte since mavlink requires a non-zero payload</field>
     </message>
@@ -5604,7 +5604,19 @@
     </message>
     <message id="13027" name="FIREFLY_IPP_TRANSMIT_COMPLETE">
       <description>Complete plan transmitted, reset IPP plan variables</description>
+      <field type="uint8_t" name="seq_num">Sequence Number</field>
+    </message>
+    <message id="13028" name="FIREFLY_RESET_BEHAVIOR_TREE">
+      <description>Command to reset behavior tree</description>
       <field type="uint8_t" name="empty">Empty byte since mavlink requires a non-zero payload</field>
+    </message>
+    <message id="13029" name="FIREFLY_IDLE">
+      <description>Command to enter an idle autonomy state</description>
+      <field type="uint8_t" name="empty">Empty byte since mavlink requires a non-zero payload</field>
+    </message>
+    <message id="13030" name="FIREFLY_IPP_TRANSMIT_START">
+      <description>Start of IPP Plan Transmission</description>
+      <field type="uint8_t" name="seq_num">Sequence Number</field>
     </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
- Overhaul the behavior tree to use a more hierarchical system, where we ensure that the local position reference has been set and we have requested control from the drone before entering an autonomy control mode that would use a trajectory controller. 
- Add autonomy mode conditions, where a max of one autonomy mode condition can be true at any given point in time. 
- The autonomy mode conditions are idle, takeoff, land, traj control, coverage planner, ipp planner. 
- Setting the local position reference is now done in the behavior executive rather than onboard telemetry
- Add idle mode and reset behavior tree action
- Add logic to allow for ipp planner to wait for an initial plan to be viewed at the GCS, and then continually replan based off a timer
- Fix bugs with transmission of the ipp initial plan
- Fix bug with onboard telemetry update of self.na
- Update telemetry rates for new radio

This has been tested fully in simulation, and parts of this PR has been tested in the field.