### PR TITLE
Add terrain mapping and altitude estimation

### DIFF
--- a/firefly_bringup/launch/gcs_bringup.launch
+++ b/firefly_bringup/launch/gcs_bringup.launch
@@ -4,10 +4,10 @@
   <env name="ROS_PYTHON_LOG_CONFIG_FILE" value="$(find firefly_bringup)/config/python_logging.conf" />
 
   <arg name="map_resolution" default="0.5" />
-  <arg name="map_min_x" default="-500" />
-  <arg name="map_max_x" default="500" />
-  <arg name="map_min_y" default="-500" />
-  <arg name="map_max_y" default="500" />
+  <arg name="map_min_x" default="-250" />
+  <arg name="map_max_x" default="250" />
+  <arg name="map_min_y" default="-250" />
+  <arg name="map_max_y" default="250" />
 
   <!-- This node maintains the local fire map-->
   <node pkg="firefly_mapping" type="gcs_mapping" name="gcs_mapping" output="screen">

--- a/firefly_bringup/launch/onboard_bringup.launch
+++ b/firefly_bringup/launch/onboard_bringup.launch
@@ -10,10 +10,11 @@
   <arg name="drone_interface" default="DJIInterface" />
   <arg name="run_ca_stack" default="true" />
   <arg name="map_resolution" default="0.5" />
-  <arg name="map_min_x" default="-500" />
-  <arg name="map_max_x" default="500" />
-  <arg name="map_min_y" default="-500" />
-  <arg name="map_max_y" default="500" />
+  <arg name="terrain_resolution" default="2.5" />
+  <arg name="map_min_x" default="-250" />
+  <arg name="map_max_x" default="250" />
+  <arg name="map_min_y" default="-250" />
+  <arg name="map_max_y" default="250" />
 
   <group ns="$(arg robot_name)">
     <node pkg="firefly_mapping" type="onboard_mapping" name="onboard_mapping" output="screen">
@@ -28,8 +29,19 @@
       <param name="threshold" value="$(arg threshold)" />
       <param name="continuous" value="$(arg continuous)" />
     </node>
+    <node pkg="firefly_perception" type="lidar_perception" name="lidar_perception" output="screen" />
+    <node pkg="firefly_mapping" type="terrain_mapping" name="terrain_mapping" output="screen">
+      <param name="terrain_resolution" value="$(arg terrain_resolution)" />
+      <param name="min_x" value="$(arg map_min_x)" />
+      <param name="max_x" value="$(arg map_max_x)" />
+      <param name="min_y" value="$(arg map_min_y)" />
+      <param name="max_y" value="$(arg map_max_y)" />
+    </node>
     <node pkg="firefly_bringup" type="pcb_interface.py" name="pcb_interface" output="screen" />
 
+    <node pkg="grid_map_visualization" type="grid_map_visualization" name="grid_map_visualization" output="screen">
+      <rosparam command="load" file="$(find firefly_mapping)/config/grid_map.yaml" />
+    </node>
     <group unless="$(arg replay_mode)">
       <include file="$(find dji_sdk)/launch/sdk.launch" />
       <include file="$(find flir_ros_sync)/launch/example/flir_ros.launch" if="$(arg open_flir)" />
@@ -37,6 +49,9 @@
       <include file="$(find core_central)/launch/dji/sim/dji_sim_state_estimation.launch" pass_all_args="true" />
       <include file="$(find velodyne_pointcloud)/launch/VLP16_points.launch" />
       <node pkg="tf" type="static_transform_publisher" name="base_to_thermal_camera_link" args="0.0543145 0.041098 -0.27658746 -1.5707963 0 3.14159 $(arg robot_name)/base_link $(arg robot_name)/thermal/camera_link 100" />
+      <node pkg="tf" type="static_transform_publisher" name="base_to_lidar" args="0.17 -0.03 -0.15 -1.5707963 0 -1.5707963 $(arg robot_name)/base_link $(arg robot_name)/lidar 100" />
+
+      <node name="rviz" pkg="rviz" type="rviz" args="-d $(find firefly_mapping)/rviz/terrain_mapping.rviz"/>
 
       <group if="$(arg run_ca_stack)">
         <include file="$(find core_central)/launch/dji/sim/dji_sim_control.launch" pass_all_args="true" />

--- a/firefly_bringup/scripts/record_rosbag.bash
+++ b/firefly_bringup/scripts/record_rosbag.bash
@@ -24,4 +24,4 @@ mkdir -p "$OUT_FOLDER"
 echo "Saving to $OUTPUT ..."
 sleep 2
 
-rosbag record -a -O "$OUT_FOLDER"/"$DATETIME"_dji_sdk_and_thermal.bag __name:="data_collect" -x "(.*)/compressed(.*)|(.*)/theora(.*)"
+rosbag record -a -O "$OUT_FOLDER"/"$DATETIME"_dji_sdk_and_thermal.bag __name:="data_collect" -x "(.*)/compressed(.*)|(.*)/theora(.*)|/uav1/lidar_cropped_mapping|/uav1/lidar_cropped_obstacle|/uav1/altitude"

--- a/firefly_bringup/scripts/record_rosbag_and_rgb.bash
+++ b/firefly_bringup/scripts/record_rosbag_and_rgb.bash
@@ -49,7 +49,7 @@ queue ! "video/x-raw(memory:NVMM),width=1920,height=1080,framerate=60/1" ! nvvid
 # run ROS record
 if rostopic list | grep -q "/rosout"; then
 	source /home/wildfire/M600_ws/devel/setup.bash
-	rosbag record -a -O "$OUT_FOLDER"/"$DATETIME"_dji_sdk_and_thermal.bag __name:="data_collect" -x "(.*)/compressed(.*)|(.*)/theora(.*)" &
+	rosbag record -a -O "$OUT_FOLDER"/"$DATETIME"_dji_sdk_and_thermal.bag __name:="data_collect" -x "(.*)/compressed(.*)|(.*)/theora(.*)|/uav1/lidar_cropped_mapping|/uav1/lidar_cropped_obstacle|/uav1/altitude" &
 else
 	echo "roscore not running, not recording DJI SDK data"
 fi

--- a/firefly_mapping/CMakeLists.txt
+++ b/firefly_mapping/CMakeLists.txt
@@ -3,6 +3,8 @@ project(firefly_mapping)
 
 add_compile_options(-std=c++17)
 
+set(PCL_DIR /usr/lib/${CMAKE_HOST_SYSTEM_PROCESSOR}-linux-gnu/cmake/pcl/)
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
@@ -12,7 +14,17 @@ find_package(catkin REQUIRED COMPONENTS
   nav_msgs
   tf
   eigen_conversions
+  grid_map_core
+  grid_map_msgs
+  grid_map_ros
+  grid_map_rviz_plugin
+  grid_map_sdf
+  grid_map_visualization
+  PCL
+  pcl_conversions
+  pcl_ros
 )
+
 add_message_files(
         FILES
         ImageWithPose.msg
@@ -55,3 +67,7 @@ target_link_libraries(gcs_mapping ${catkin_LIBRARIES})
 add_executable(mapping_accuracy src/mapping_accuracy.cpp)
 add_dependencies(mapping_accuracy ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(mapping_accuracy ${catkin_LIBRARIES})
+
+add_executable(terrain_mapping src/terrain_mapping.cpp)
+add_dependencies(terrain_mapping ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(terrain_mapping ${catkin_LIBRARIES})

--- a/firefly_mapping/config/grid_map.yaml
+++ b/firefly_mapping/config/grid_map.yaml
@@ -1,0 +1,12 @@
+grid_map_topic: /uav1/grid_map
+grid_map_visualizations:
+  - name: elevation_points
+    type: point_cloud
+    params:
+     layer: elevation
+  - name: elevation_grid
+    type: occupancy_grid
+    params:
+     layer: elevation
+     data_min: -100.0
+     data_max: 100.0

--- a/firefly_mapping/package.xml
+++ b/firefly_mapping/package.xml
@@ -44,4 +44,11 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>message_runtime</exec_depend>
+
+  <depend>grid_map_core</depend>
+  <depend>grid_map_msgs</depend>
+  <depend>grid_map_ros</depend>
+  <depend>grid_map_rviz_plugin</depend>
+  <depend>grid_map_sdf</depend>
+  <depend>grid_map_visualization</depend>
 </package>

--- a/firefly_mapping/rviz/terrain_mapping.rviz
+++ b/firefly_mapping/rviz/terrain_mapping.rviz
@@ -1,0 +1,275 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Grid1
+        - /PointCloud21
+        - /GridMap1
+        - /TF1
+        - /TF1/Frames1
+        - /Image1
+        - /PointCloud22
+      Splitter Ratio: 0.5
+    Tree Height: 192
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: false
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 1000
+      Reference Frame: <Fixed Frame>
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 0; 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: /uav1/lidar_cropped_mapping
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Class: grid_map_rviz_plugin/GridMap
+      Color: 200; 200; 200
+      Color Layer: elevation
+      Color Transformer: GridMapLayer
+      ColorMap: default
+      Enabled: true
+      Grid Cell Decimation: 1
+      Grid Line Thickness: 0.10000000149011612
+      Height Layer: elevation
+      Height Transformer: GridMapLayer
+      History Length: 1
+      Invert ColorMap: false
+      Max Color: 255; 255; 255
+      Max Intensity: 10
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: GridMap
+      Show Grid Lines: true
+      Topic: /uav1/grid_map
+      Unreliable: false
+      Use ColorMap: true
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        camera_coords:
+          Value: true
+        local_enu:
+          Value: true
+        uav1/base_link:
+          Value: false
+        uav1/base_link_stabilized:
+          Value: true
+        uav1/lidar:
+          Value: true
+        uav1/look_ahead_point:
+          Value: true
+        uav1/look_ahead_point_stabilized:
+          Value: true
+        uav1/map:
+          Value: false
+        uav1/thermal/camera_link:
+          Value: true
+        uav1/tracking_point:
+          Value: true
+        uav1/tracking_point_stabilized:
+          Value: true
+        world:
+          Value: true
+      Marker Scale: 5
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        world:
+          uav1/map:
+            uav1/base_link:
+              uav1/lidar:
+                {}
+              uav1/thermal/camera_link:
+                {}
+            uav1/base_link_stabilized:
+              {}
+            uav1/look_ahead_point:
+              {}
+            uav1/look_ahead_point_stabilized:
+              {}
+            uav1/tracking_point:
+              {}
+            uav1/tracking_point_stabilized:
+              {}
+      Update Interval: 0
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /uav1/seek_camera/displayImage
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: z
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Min Color: 0; 85; 127
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 2.5
+      Style: Flat Squares
+      Topic: /uav1/grid_map_visualization/elevation_points
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: uav1/map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 341.64599609375
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -4.751351356506348
+        Y: -2.9436187744140625
+        Z: 2.74045467376709
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.8218047022819519
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.7574769258499146
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1056
+  Hide Left Dock: false
+  Hide Right Dock: true
+  Image:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000035400000398fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000027000000fd000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065010000012a000002950000001600ffffff000000010000010f00000398fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000002700000398000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000074b0000003efc0100000002fb0000000800540069006d006501000000000000074b000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000003f10000039800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1867
+  X: 53
+  Y: 24

--- a/firefly_mapping/src/terrain_mapping.cpp
+++ b/firefly_mapping/src/terrain_mapping.cpp
@@ -1,0 +1,166 @@
+#include <grid_map_msgs/GridMap.h>
+#include <nav_msgs/Odometry.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl_ros/transforms.h>
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <tf/transform_listener.h>
+
+#include <visualization_msgs/MarkerArray.h>
+
+#include <cmath>
+#include <grid_map_ros/grid_map_ros.hpp>
+#include <unordered_map>
+#include <vector>
+
+#include "sensor_msgs/PointCloud2.h"
+
+using namespace grid_map;
+
+class TerrainMapping {
+ public:
+  TerrainMapping() : pnh("~"), map({"elevation"}) {
+    cloud_sub = nh.subscribe("lidar_cropped_mapping", 1,
+                             &TerrainMapping::cloudCallback, this);
+
+    grid_map_pub = nh.advertise<grid_map_msgs::GridMap>("grid_map", 1);
+
+    pnh.param<float>("terrain_resolution", resolution, 0.5);
+    pnh.param<float>("min_x", minX, -100.0);
+    pnh.param<float>("max_x", maxX, 100.0);
+    pnh.param<float>("min_y", minY, -100.0);
+    pnh.param<float>("max_y", maxY, 100.0);
+
+    float lengthX = maxX - minX;
+    float lengthY = maxY - minY;
+
+    map.setFrameId("uav1/map");
+    map.setGeometry(grid_map::Length(lengthX, lengthY), resolution);
+    mapWidth = map.getSize()(0);
+    mapHeight = map.getSize()(1);
+    map.add("elevation", grid_map::Matrix::Constant(
+                             mapWidth, mapHeight,
+                             0));  // Initialize map to 50 percent certainty
+    ROS_INFO("Created map with size %f x %f m (%i x %i cells).",
+             map.getLength().x(), map.getLength().y(), map.getSize()(0),
+             map.getSize()(1));
+
+    map_pub_timer = nh.createTimer(ros::Duration(1.0),
+                                   &TerrainMapping::publish_map_callback, this);
+  }
+
+ private:
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh;
+  ros::Subscriber cloud_sub;
+  ros::Publisher grid_map_pub;
+  ros::Timer map_pub_timer;
+
+  GridMap map;
+
+  tf::TransformListener listener;
+
+  float resolution;
+  float minX;
+  float maxX;
+  float minY;
+  float maxY;
+  int mapWidth;   // Number of cells
+  int mapHeight;  // Number of cells
+
+  void cloudCallback(const sensor_msgs::PointCloud2::ConstPtr& cloud) {
+    auto start = std::chrono::high_resolution_clock::now();
+    std::unordered_map<int, float> map_bin_to_max_altitude;
+
+    try {
+      sensor_msgs::PointCloud2 cloud_target_frame;
+      // listener.waitForTransform("uav1/map", "uav1/lidar", cloud.header.stamp,
+      //                           ros::Duration(0.1));
+
+      pcl_ros::transformPointCloud("uav1/map", *cloud, cloud_target_frame,
+                                   listener);
+
+      pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud2_map_pcl(
+          new pcl::PointCloud<pcl::PointXYZ>());
+      pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud2_sensor_pcl(
+          new pcl::PointCloud<pcl::PointXYZ>());
+
+      pcl::fromROSMsg(*cloud, *pointcloud2_sensor_pcl);
+      pcl::fromROSMsg(cloud_target_frame, *pointcloud2_map_pcl);
+
+      unsigned int size = (unsigned int)pointcloud2_map_pcl->points.size();
+
+      for (unsigned int k = 0; k < size; ++k) {
+        const pcl::PointXYZ& pt_cloud = pointcloud2_map_pcl->points[k];
+
+        // check for invalid measurements
+        if (isnan(pt_cloud.x) || isnan(pt_cloud.y) || isnan(pt_cloud.z))
+          continue;
+
+        const auto& sensor_x = pointcloud2_sensor_pcl->points[k].x;
+        const auto& sensor_y = pointcloud2_sensor_pcl->points[k].y;
+        const auto& sensor_z = pointcloud2_sensor_pcl->points[k].z;
+        const float measurement_distance =
+            sqrt(pow(sensor_x, 2) + pow(sensor_y, 2) + pow(sensor_z, 2));
+
+        static constexpr float MAX_OBSERVABLE_DISTANCE = 100;
+        static constexpr float MIN_OBSERVABLE_DISTANCE = 1.0;
+        if (MAX_OBSERVABLE_DISTANCE < measurement_distance || measurement_distance < MIN_OBSERVABLE_DISTANCE) continue;
+
+        const int grid_map_col =  mapHeight - (const int)((pt_cloud.y - minY) / resolution);
+        const int grid_map_row = mapWidth - (const int)((pt_cloud.x - minX) / resolution);
+
+        const bool valid_row = (0 <= grid_map_row) && (grid_map_row < mapWidth);
+        const bool valid_col = (0 <= grid_map_col) && (grid_map_col < mapHeight);
+
+        if (!valid_row || !valid_col) {
+          continue;
+        }
+
+        int mapBin = grid_map_col + grid_map_row * mapHeight;
+
+        const auto search = map_bin_to_max_altitude.find(mapBin);
+        if (search == map_bin_to_max_altitude.end() ||
+            pt_cloud.z > search->second) {
+          map_bin_to_max_altitude[mapBin] = pt_cloud.z;
+        }
+      }
+    } catch (tf::TransformException& ex) {
+      ROS_ERROR_STREAM(
+          "Transform Exception in distance_to_obstacle while looking up tf: "
+          << ex.what());
+    }
+
+    for (const auto iter : map_bin_to_max_altitude) {
+      const auto map_bin = iter.first;
+      const auto bin_height = iter.second;
+
+      const int grid_row = floor(map_bin / mapHeight);
+      const int grid_col = map_bin % mapHeight;
+
+      grid_map::Index index{grid_row, grid_col};
+      map.at("elevation", index) = bin_height;
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    std::cout << "Mapping of point cloud took: " << duration.count() << " milliseconds" << std::endl;
+  }
+
+  void publish_map_callback(const ros::TimerEvent& e) {
+    ros::Time time = ros::Time::now();
+    map.setTimestamp(time.toNSec());
+    grid_map_msgs::GridMap message;
+    GridMapRosConverter::toMessage(map, message);
+    grid_map_pub.publish(message);
+    ROS_INFO_THROTTLE(1.0, "Grid map (timestamp %f) published.",
+                      message.info.header.stamp.toSec());
+  }
+};
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "firefly_terrain_mapping");
+  TerrainMapping node;
+  ros::spin();
+  return 0;
+}

--- a/firefly_perception/CMakeLists.txt
+++ b/firefly_perception/CMakeLists.txt
@@ -4,9 +4,8 @@ project(firefly_perception)
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
+set(PCL_DIR /usr/lib/${CMAKE_HOST_SYSTEM_PROCESSOR}-linux-gnu/cmake/pcl/)
+
 find_package(catkin REQUIRED COMPONENTS
   cv_bridge
   firefly_mapping
@@ -16,6 +15,9 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   std_msgs
   tf
+  PCL
+  pcl_conversions
+  pcl_ros
 )
 find_package(
   OpenCV
@@ -41,4 +43,11 @@ include_directories(
 add_executable(firefly_perception src/firefly_perception.cpp)
 target_link_libraries(firefly_perception
                             ${catkin_LIBRARIES}
-                            ${OpenCV_LIBRARIES})
+                            ${OpenCV_LIBRARIES}
+                            ${PCL_LIBRARIES})
+
+add_executable(lidar_perception src/lidar_perception.cpp)
+target_link_libraries(lidar_perception
+                            ${catkin_LIBRARIES}
+                            ${OpenCV_LIBRARIES}
+                            ${PCL_LIBRARIES})

--- a/firefly_perception/src/lidar_perception.cpp
+++ b/firefly_perception/src/lidar_perception.cpp
@@ -1,0 +1,105 @@
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <vector>
+#include <algorithm>
+#include <std_msgs/Empty.h>
+#include <std_msgs/Float64.h>
+#include <firefly_mapping/ImageWithPose.h>
+#include <tf/transform_listener.h>
+#include <tf/transform_broadcaster.h>
+
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/point_types.h>
+#include <pcl/PCLPointCloud2.h>
+#include <pcl/filters/crop_box.h>
+#include <pcl_ros/transforms.h>
+#include "pcl_ros/point_cloud.h"
+
+
+class LidarReader 
+{
+    ros::NodeHandle nh_;
+    ros::NodeHandle private_nh_;
+    
+    sensor_msgs::PointCloud2 input_pointcloud_;
+
+    ros::Publisher lidar_mapping_pub_;
+    ros::Publisher lidar_obstacle_pub_;
+    ros::Publisher lidar_altitude_pub_;
+    ros::Publisher altitude_pub_;
+
+    ros::Subscriber lidar_subscriber;
+
+public:
+    LidarReader() : private_nh_("~")
+    {
+        lidar_subscriber = nh_.subscribe("velodyne_points", 1, &LidarReader::point_cloud_extractor, this);
+        
+        lidar_mapping_pub_ = nh_.advertise< pcl::PointCloud<pcl::PointXYZ>>("lidar_cropped_mapping", 1);
+        lidar_obstacle_pub_ = nh_.advertise< pcl::PointCloud<pcl::PointXYZ>>("lidar_cropped_obstacle", 1);
+        lidar_altitude_pub_ = nh_.advertise< pcl::PointCloud<pcl::PointXYZ>>("altitude", 1);
+        altitude_pub_ = nh_.advertise<std_msgs::Float64>("perception_height_estimation", 2);
+    }
+
+    ~LidarReader()
+    {
+        ROS_DEBUG("GET GOT. BYE LIDAR");
+    }
+
+    void point_cloud_extractor(const sensor_msgs::PointCloud2::ConstPtr& msg)
+    {
+        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_pcl(new pcl::PointCloud<pcl::PointXYZ>);
+        pcl::fromROSMsg(*msg, *cloud_pcl);
+        
+        pcl::PCLPointCloud2 point_cloud2_mappping;
+        pcl::CropBox<pcl::PointXYZ> cropBoxFilterMapping (true);
+        cropBoxFilterMapping.setInputCloud (cloud_pcl);    
+        Eigen::Vector4f min_pt_mapping (-20.0f, 0.0f, -100.0f, 1.0f);
+        Eigen::Vector4f max_pt_mapping (20.0f, 100.0f, 100.0f, 1.0f);
+        pcl::PointCloud<pcl::PointXYZ> cloud_out_mapping;
+        cropBoxFilterMapping.setMin (min_pt_mapping);
+        cropBoxFilterMapping.setMax (max_pt_mapping);
+        cropBoxFilterMapping.filter (cloud_out_mapping);
+        pcl::toPCLPointCloud2(cloud_out_mapping, point_cloud2_mappping);
+        point_cloud2_mappping.header.frame_id = "/uav1/lidar";
+
+        lidar_mapping_pub_.publish(point_cloud2_mappping);
+
+        pcl::CropBox<pcl::PointXYZ> cropBoxFilterAltitude (true);
+        cropBoxFilterAltitude.setInputCloud (cloud_pcl);
+        Eigen::Vector4f min_pt_altitude (-0.1f, 0.0f, -0.1f, 1.0f);
+        Eigen::Vector4f max_pt_altitude (0.1f, 100.0f, 0.1f, 1.0f);
+        pcl::PointCloud<pcl::PointXYZ> cloud_out_altitude;
+        cropBoxFilterAltitude.setMin (min_pt_altitude);
+        cropBoxFilterAltitude.setMax (max_pt_altitude);
+        cropBoxFilterAltitude.filter (cloud_out_altitude);
+        cloud_out_altitude.header.frame_id = "/uav1/lidar";
+        lidar_altitude_pub_.publish(cloud_out_altitude);
+        
+        float height = 0;
+        for (int i = 0; i < cloud_out_altitude.points.size(); i++)
+        {
+            height += cloud_out_altitude.points[i].y;
+        }
+        
+        if (cloud_out_altitude.points.size() != 0 ) {
+            height /= cloud_out_altitude.points.size();
+        }
+        else {
+            height = -1;
+        }
+            
+        std_msgs::Float64 altitude;
+        altitude.data = height;
+        altitude_pub_.publish(altitude);
+    }
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "LidarPerception");
+    LidarReader ic; 
+    ros::spin();
+    return 0;
+}
+

--- a/firefly_telemetry/src/gcs_telemetry.py
+++ b/firefly_telemetry/src/gcs_telemetry.py
@@ -59,6 +59,8 @@ class GCSTelemetry:
         rospy.Subscriber("stop_record_rosbag", Empty, self.stop_record_ros_bag_callback)
         rospy.Subscriber("execute_ipp_plan", Empty, self.execute_ipp_plan_callback)
         rospy.Subscriber("idle", Empty, self.idle_callback)
+        rospy.Subscriber("start_terrain_mapping", Empty, self.start_terrain_mapping_callback)
+        rospy.Subscriber("stop_terrain_mapping", Empty, self.stop_terrain_mapping_callback)
         rospy.Subscriber(
             "reset_behavior_tree", Empty, self.reset_behavior_tree_callback
         )
@@ -97,6 +99,8 @@ class GCSTelemetry:
         self.stop_record_ros_bag_send_flag = False
         self.execute_ipp_plan_flag = False
         self.idle_send_flag = False
+        self.start_terrain_mapping_send_flag = False
+        self.stop_terrain_mapping_send_flag = False
         self.reset_behavior_tree_send_flag = False
 
         self.bytes_per_sec_send_rate = 2000.0
@@ -430,6 +434,22 @@ class GCSTelemetry:
             rospy.sleep(
                 (self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate
             )
+        
+        if self.start_terrain_mapping_send_flag:
+            rospy.loginfo("Starting Terrain Mapping")
+            self.connection.mav.firefly_start_terrain_mapping_send(1)
+            self.start_terrain_mapping_send_flag = False
+            rospy.sleep(
+                (self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate
+            )
+                
+        if self.stop_terrain_mapping_send_flag:
+            rospy.loginfo("Stopping Terrain Mapping")
+            self.connection.mav.firefly_stop_terrain_mapping_send(1)
+            self.stop_terrain_mapping_send_flag = False
+            rospy.sleep(
+                (self.mavlink_packet_overhead_bytes + 1) / self.bytes_per_sec_send_rate
+            )
 
         if self.reset_behavior_tree_send_flag:
             rospy.loginfo("Resetting behavior tree")
@@ -515,6 +535,12 @@ class GCSTelemetry:
 
     def idle_callback(self, empty_msg):
         self.idle_send_flag = True
+
+    def start_terrain_mapping_callback(self, empty_msg):
+        self.start_terrain_mapping_send_flag = True
+
+    def stop_terrain_mapping_callback(self, empty_msg):
+        self.stop_terrain_mapping_send_flag = True
 
     def reset_behavior_tree_callback(self, empty_msg):
         self.reset_behavior_tree_send_flag = True

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -467,7 +467,7 @@ class OnboardTelemetry:
                 dir = DEFAULT_ROOT + "/" + time_rosbag
                 rospy.loginfo("Starting ros bag recording to file : " + dir + time_rosbag + "_dji_sdk_and_thermal.bag")
                 os.system(
-                    "rosbag record -a -O " + dir + "_dji_sdk_and_thermal.bag __name:='data_collect' -x '(.*)/compressed(.*)|(.*)/theora(.*)' &")
+                    "rosbag record -a -O " + dir + "_dji_sdk_and_thermal.bag __name:='data_collect' -x '(.*)/compressed(.*)|(.*)/theora(.*))|/uav1/lidar_cropped_mapping|/uav1/lidar_cropped_obstacle|/uav1/altitude' &")
                 self.recording_ros_bag = True
             elif msg['get_frame'] == 0 and self.recording_ros_bag:
                 rospy.loginfo("Stopping ros bag recording")

--- a/firefly_telemetry/src/onboard_telemetry.py
+++ b/firefly_telemetry/src/onboard_telemetry.py
@@ -89,6 +89,7 @@ class OnboardTelemetry:
         self.clear_map_pub = rospy.Publisher("clear_map", Empty, queue_size=100)
         self.behavior_tree_commands_pub = rospy.Publisher("behavior_tree_commands", BehaviorTreeCommands, queue_size=100)
         self.kill_switch = rospy.Publisher("kill_switch", Empty, queue_size=10)
+        self.enable_terrain_mapping_pub = rospy.Publisher("enable_terrain_mapping", Bool, queue_size=10)
 
         rospy.Timer(rospy.Duration(0.5), self.pose_send_callback)
         self.extract_frame_pub = rospy.Publisher("extract_frame", Empty, queue_size=1)
@@ -516,6 +517,10 @@ class OnboardTelemetry:
             command.condition_name = "Autonomy Mode Is Idle"
             command.status = Status.SUCCESS
             behavior_tree_commands.commands.append(command)
+        elif msg["mavpackettype"] == "FIREFLY_START_TERRAIN_MAPPING":
+            self.enable_terrain_mapping_pub.publish(True)
+        elif msg["mavpackettype"] == "FIREFLY_STOP_TERRAIN_MAPPING":
+            self.enable_terrain_mapping_pub.publish(False)
         elif msg["mavpackettype"] == "FIREFLY_TAKEOFF":
             command = BehaviorTreeCommand()
             command.condition_name = "Autonomy Mode Is Takeoff"

--- a/pymavlink/message_definitions/v1.0/firefly.xml
+++ b/pymavlink/message_definitions/v1.0/firefly.xml
@@ -5636,5 +5636,13 @@
       <description>Acknowledge receipt of coverage polygon point</description>
       <field type="uint8_t" name="seq_num">Sequence Number</field>
     </message>
+    <message id="13034" name="FIREFLY_START_TERRAIN_MAPPING">
+      <description>Command to start projecting point clouds to map the terrain</description>
+      <field type="uint8_t" name="empty">Empty byte since mavlink requires a non-zero payload</field>
+    </message>
+    <message id="13035" name="FIREFLY_STOP_TERRAIN_MAPPING">
+      <description>Command to stop projecting point clouds for terrain mapping</description>
+      <field type="uint8_t" name="empty">Empty byte since mavlink requires a non-zero payload</field>
+    </message>
   </messages>
 </mavlink>


### PR DESCRIPTION
Add lidar perception node to filter the velodyne point cloud into two point clouds - one point cloud more directly under the drone for estimating altitude, and one point cloud below the drone for mapping the terrain. Add a terrain mapping node to bin points from a point cloud into grid cells to form a terrain elevation map. If multiple points fall into a bin, take the max height. New point clouds overwrite results in grid cells from older point clouds. Add ability to start and stop terrain mapping using telemetry. Tested using HITL simulation. 