### PR TITLE
Handle non-x-monotone polygons in coverage planner

### DIFF
--- a/firefly_control/src/plot_coverage_planner.py
+++ b/firefly_control/src/plot_coverage_planner.py
@@ -15,6 +15,34 @@ def plot_cell_traversal(path: List[Trapezoidal_Cell]) -> None:
         )
 
 
+def rotate_path(xy_path, angle_deg):
+    angle_rad = np.deg2rad(angle_deg)
+    rotated_xy_path = []
+    for (x, y) in xy_path:
+        new_x = x * np.cos(angle_rad) - y * np.sin(angle_rad)
+        new_y = x * np.sin(angle_rad) + y * np.cos(angle_rad)
+        rotated_xy_path.append((new_x, new_y))
+    return rotated_xy_path
+
+
+def rotate_polygon(polygon: List[Point2d], angle_deg):
+    angle_rad = np.deg2rad(angle_deg)
+    rotated_polygon = []
+    for point in polygon:
+        new_x = point.x * np.cos(angle_rad) - point.y * np.sin(angle_rad)
+        new_y = point.x * np.sin(angle_rad) + point.y * np.cos(angle_rad)
+        rotated_polygon.append(Point2d(new_x, new_y))
+    return rotated_polygon
+
+
+def rotate_holey_polygon(
+    outer_boundary: List[Point2d], holes: List[List[Point2d]], angle_deg
+):
+    outer_boundary = rotate_polygon(outer_boundary, angle_deg)
+    holes = [rotate_polygon(hole, angle_deg) for hole in holes]
+    return outer_boundary, holes
+
+
 def plot_cell(cell) -> None:
     points = cell.get_vertices()
     plt.fill([p.x for p in points], [p.y for p in points])
@@ -73,25 +101,40 @@ if __name__ == "__main__":
     #     Point2d(-6.6, -2),
     #     Point2d(-2.27, 0),
     # ]
+    # outer_boundary = [
+    #     Point2d(90, 0),
+    #     Point2d(70, 50),
+    #     Point2d(20, 50),
+    #     Point2d(0, 0),
+    # ]
     outer_boundary = [
         Point2d(90, 0),
-        Point2d(70, 50),
-        Point2d(20, 50),
+        Point2d(90, 100),
+        Point2d(0, 100),
         Point2d(0, 0),
     ]
+    outer_boundary = [
+        Point2d(0, 100),
+        Point2d(0, 0),
+        Point2d(150, 0),
+        Point2d(150, 150),
+        Point2d(0, 150),
+        Point2d(0, 110),
+        Point2d(90, 110),
+        Point2d(90, 100),
+    ]
 
-    hole1 = [Point2d(30, 20), Point2d(45, 40), Point2d(60, 20)]
+    # hole = [Point2d(30, 20), Point2d(45, 40), Point2d(60, 20)]
+    hole1 = [Point2d(30, 30), Point2d(30, 40), Point2d(60, 40), Point2d(60, 30)]
+    hole2 = [Point2d(30, 10), Point2d(30, 20), Point2d(60, 20), Point2d(60, 10)]
+    hole3 = [Point2d(30, 50), Point2d(30, 60), Point2d(60, 60), Point2d(60, 50)]
+    hole4 = [Point2d(30, 70), Point2d(30, 80), Point2d(60, 80), Point2d(60, 70)]
+    hole5 = [Point2d(110, 60), Point2d(120, 110), Point2d(130, 50)]
 
-    holes = [hole1]
-    cells = trapezoidal_decomposition(outer_boundary, holes)
-    cell_path = generate_cell_traversal(cells)
-    path = get_full_coverage_path(cell_path, 10)
-    print(path)
-
-    for cell in cells:
-        plot_cell(cell)
-        # cell.plot_adjancency_edges()
-    # plot_cell_traversal(cell_path)
+    holes = [hole1, hole2, hole3, hole4, hole5]
+    # holes = [hole]
+    angle_deg = 0
+    outer_boundary, holes = rotate_holey_polygon(outer_boundary, holes, -angle_deg)
 
     xs = [outer_boundary[i].x for i in range(len(outer_boundary))]
     ys = [outer_boundary[i].y for i in range(len(outer_boundary))]
@@ -101,6 +144,17 @@ if __name__ == "__main__":
         xs = [hole[i].x for i in range(len(hole))]
         ys = [hole[i].y for i in range(len(hole))]
         plt.plot(xs + [xs[0]], ys + [ys[0]], linewidth=2.5, color="red")
+
+    cells = trapezoidal_decomposition(outer_boundary, holes)
+    cell_path = generate_cell_traversal(cells)
+    path = get_full_coverage_path(cell_path, 5)
+    # path = rotate_path(path, angle_deg)
+    # print(path)
+
+    for cell in cells:
+        plot_cell(cell)
+    #     plot_cell_adjancency_edges(cell)
+    # plot_cell_traversal(cell_path)
 
     path_xs = [path[i][0] for i in range(len(path))]
     path_ys = [path[i][1] for i in range(len(path))]


### PR DESCRIPTION
Before this PR, the coverage planner was capable of covering any polygon with polygonal holes, so long as no vertices share the same x-coordinate. Vertices sharing an x-coordinate posed a problem for our vertical line sweeping method used to generate a trapezoidal decomposition of the shapes. This is problematic because it means we would not be able to generate a coverage plan for common shapes such as rectangles. In order to fix this, I had to make two changes. The first change was to make the event type more general. In our coverage planner, events correspond to vertices of the region to cover. Previously, events would store the vertex of interest, as well as the next and previous vertex for that polygon. Under the constraint that the area to cover is kept to the left of each polygon as you traverse the vertices in order, then the current, previous, and next vertex were sufficient to classify events into 6 different types, shown below in figure 1. Each type is handled differently as the sweep line processes each event in order from left to right. At “open” events, we create a new open trapezoid (An open trapezoid is one where the right edge is not yet defined). At “close” events, we close a trapezoid (add the right edge) without opening any new trapezoids. At “floor” and “ceiling” events, we close one trapezoid and open a new one. At “in” events, we close one trapezoid and open two new ones. Finally, at “out” events, we close two trapezoids and open a new one. In the case where two vertices share the same x-coordinate, such an event would not fit into any of the 6 existing categories. To handle this case, I changed events from having a one-to-one correspondence with vertices to now allow one event to correspond to multiple vertices. Instead of having a single vertex of interest, we now group consecutive vertices with the same x-coordinate into a single event. We ensure that the next and previous vertex (shown as v_n+1 and v_n-1 in figure 1) have a distinct x-coordinate from this vertices of interest list. This allows us to still use the same 6 event types shown in figure 1, but v_n now becomes a list of vertices forming a vertical line rather than a single vertex. 

![image](https://user-images.githubusercontent.com/55460423/202846461-d44eb6b3-4201-42a5-9478-74b5a67509b3.png)

Figure 1: Different event classifications that are used for generating a trapezoidal decomposition. The red area corresponds to the area of interest that should be covered. 

Making this change to the event class is sufficient for handling the case where consecutive vertices in the same polygon have the same x-coordinate. Such is the case for shapes like rectangles. However, it does not handle the case where non-consecutive vertices in a polygon or vertices from two different polygons have the same x-coordinate. I found that in such a case, we end up forming degenerate trapezoids with zero area, since, as we process the two events at the same x-coordinate, we end up opening and closing a trapezoid at the same x-coordinate. This results in trapezoids where the left and right vertical edges are at the same place. I was able to fix this by creating a function which, after trapezoidal decomposition is performed, removes degenerate trapezoids and connects all the neighbors for a given degenerate trapezoid together. With these two fixes, the coverage planner is now able to generate coverage plans for any polygon with holes. Some example plans are shown below in figure 2. 

![image](https://user-images.githubusercontent.com/55460423/202846471-012a6b52-e3bc-4d01-a299-5217500237bc.png)

Figure 2: Generated coverage plans for different coverage geometries. White represents the outside area which should not be covered. Black represents the generated coverage path. The other colors correspond to different trapezoid cells generated by trapezoidal decomposition
